### PR TITLE
Use of type jit_type_void_ptr instead of jit_type_int to pass pointer through JIT calls

### DIFF
--- a/parser/Body.cpp
+++ b/parser/Body.cpp
@@ -42,5 +42,5 @@ jit_value_t Body::compile_jit(Compiler& c, jit_function_t& F, Type type) const {
 			instructions[i]->compile_jit(c, F, type);
 		}
 	}
-	return JIT_CREATE_CONST(F, JIT_INTEGER, (long) LSNull::null_var);
+	return JIT_CREATE_CONST_POINTER(F,LSNull::null_var);
 }

--- a/parser/instruction/Break.cpp
+++ b/parser/instruction/Break.cpp
@@ -22,5 +22,5 @@ jit_value_t Break::compile_jit(Compiler& c, jit_function_t& F, Type type) const 
 
 	jit_insn_branch(F, c.get_current_loop_end_label());
 
-	return jit_value_create_nint_constant(F, jit_type_int, (long int) LSNull::null_var);
+	return JIT_CREATE_CONST_POINTER(F, LSNull::null_var);
 }

--- a/parser/instruction/ClassDeclaration.cpp
+++ b/parser/instruction/ClassDeclaration.cpp
@@ -22,5 +22,5 @@ void ClassDeclaration::analyse(SemanticAnalyser* analyser, const Type& req_type)
 }
 
 jit_value_t ClassDeclaration::compile_jit(Compiler& c, jit_function_t& F, Type) const {
-	return JIT_CREATE_CONST(F, JIT_INTEGER, (long int) LSNull::null_var);
+	return JIT_CREATE_CONST_POINTER(F, LSNull::null_var);
 }

--- a/parser/instruction/Continue.cpp
+++ b/parser/instruction/Continue.cpp
@@ -22,5 +22,5 @@ jit_value_t Continue::compile_jit(Compiler& c, jit_function_t& F, Type) const {
 
 	jit_insn_branch(F, c.get_current_loop_cond_label());
 
-	return jit_value_create_nint_constant(F, jit_type_int, (long int) LSNull::null_var);
+	return JIT_CREATE_CONST_POINTER(F, LSNull::null_var);
 }

--- a/parser/instruction/For.cpp
+++ b/parser/instruction/For.cpp
@@ -75,7 +75,7 @@ int for_is_true(LSValue* v) {
 jit_value_t For::compile_jit(Compiler& c, jit_function_t& F, Type req_type) const {
 
 	if (body->instructions.size() == 0 && condition == nullptr) {
-		return JIT_CREATE_CONST(F, JIT_INTEGER, (long int) LSNull::null_var);
+		return JIT_CREATE_CONST_POINTER(F, LSNull::null_var);
 	}
 
 	// Initialization
@@ -94,7 +94,7 @@ jit_value_t For::compile_jit(Compiler& c, jit_function_t& F, Type req_type) cons
 			jit_value_t val = variablesValues.at(i)->compile_jit(c, F, Type::NEUTRAL);
 			jit_insn_store(F, var, val);
 		} else {
-			jit_value_t val = JIT_CREATE_CONST(F, JIT_INTEGER, (long int) LSNull::null_var);
+			jit_value_t val = JIT_CREATE_CONST_POINTER(F, LSNull::null_var);
 			jit_insn_store(F, var, val);
 		}
 	}
@@ -103,8 +103,8 @@ jit_value_t For::compile_jit(Compiler& c, jit_function_t& F, Type req_type) cons
 	jit_label_t label_it = jit_label_undefined;
 	jit_label_t label_end = jit_label_undefined;
 	jit_value_t const_true = JIT_CREATE_CONST(F, JIT_INTEGER, 1);
-	jit_type_t args_types[1] = {jit_type_int};
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_INTEGER, args_types, 1, 0);
+	jit_type_t args_types[1] = {JIT_POINTER};
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_POINTER, args_types, 1, 0);
 
 	c.enter_loop(&label_end, &label_it);
 
@@ -141,5 +141,5 @@ jit_value_t For::compile_jit(Compiler& c, jit_function_t& F, Type req_type) cons
 
 	c.leave_loop();
 
-	return JIT_CREATE_CONST(F, JIT_INTEGER, (long int) LSNull::null_var);
+	return JIT_CREATE_CONST_POINTER(F,LSNull::null_var);
 }

--- a/parser/instruction/For.cpp
+++ b/parser/instruction/For.cpp
@@ -83,12 +83,22 @@ jit_value_t For::compile_jit(Compiler& c, jit_function_t& F, Type req_type) cons
 
 		SemanticVar* v = vars.at(variables.at(i));
 
-		jit_value_t var = jit_value_create(F, JIT_INTEGER);
+		jit_value_t var;
 
 		if (v->scope == VarScope::GLOBAL) {
-			globals.insert(pair<string, jit_value_t>(variables[i], var));
+			auto previous_var = globals.find(variables[i]);
+			if (previous_var == globals.end()) {
+				var = jit_value_create(F, JIT_INTEGER);
+				globals.insert(pair<string, jit_value_t>(variables[i], var));
+			} else
+				var = previous_var->second;
 		} else {
-			locals.insert(pair<string, jit_value_t>(variables[i], var));
+			auto previous_var = locals.find(variables[i]);
+			if (previous_var == locals.end()) {
+				var = jit_value_create(F, JIT_INTEGER);
+				locals.insert(pair<string, jit_value_t>(variables[i], var));
+			} else
+				var = previous_var->second;
 		}
 		if (variablesValues.at(i) != nullptr) {
 			jit_value_t val = variablesValues.at(i)->compile_jit(c, F, Type::NEUTRAL);
@@ -104,7 +114,7 @@ jit_value_t For::compile_jit(Compiler& c, jit_function_t& F, Type req_type) cons
 	jit_label_t label_end = jit_label_undefined;
 	jit_value_t const_true = JIT_CREATE_CONST(F, JIT_INTEGER, 1);
 	jit_type_t args_types[1] = {JIT_POINTER};
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_POINTER, args_types, 1, 0);
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_INTEGER, args_types, 1, 0);
 
 	c.enter_loop(&label_end, &label_it);
 

--- a/parser/instruction/Foreach.cpp
+++ b/parser/instruction/Foreach.cpp
@@ -84,7 +84,7 @@ jit_value_t Foreach::compile_jit(Compiler& c, jit_function_t& F, Type) const {
 
 	// Get array size
 	jit_type_t args_types[1] = {JIT_POINTER};
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_POINTER, args_types, 1, 0);
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_INTEGER, args_types, 1, 0);
 	jit_value_t size = jit_insn_call_native(F, "size", (void*) get_array_size, sig, &a, 1, JIT_CALL_NOTHROW);
 
 

--- a/parser/instruction/VariableDeclaration.cpp
+++ b/parser/instruction/VariableDeclaration.cpp
@@ -94,7 +94,7 @@ jit_value_t VariableDeclaration::compile_jit(Compiler& c, jit_function_t& F, Typ
 			} else {
 
 				globals_types.insert(pair<string, Type>(variables[i], Type::NULLL));
-				jit_value_t val = JIT_CREATE_CONST(F, JIT_INTEGER, (long) LSNull::null_var);
+				jit_value_t val = JIT_CREATE_CONST_POINTER(F, LSNull::null_var);
 				jit_insn_store(F, var, val);
 			}
 		} else {
@@ -116,11 +116,11 @@ jit_value_t VariableDeclaration::compile_jit(Compiler& c, jit_function_t& F, Typ
 				}
 			} else {
 
-				jit_value_t val = JIT_CREATE_CONST(F, JIT_INTEGER, (long) LSNull::null_var);
+				jit_value_t val = JIT_CREATE_CONST_POINTER(F, LSNull::null_var);
 				jit_insn_store(F, var, val);
 				return val;
 			}
 		}
 	}
-	return JIT_CREATE_CONST(F, JIT_INTEGER, (long int) LSNull::null_var);
+	return JIT_CREATE_CONST_POINTER(F, LSNull::null_var);
 }

--- a/parser/instruction/While.cpp
+++ b/parser/instruction/While.cpp
@@ -35,7 +35,7 @@ jit_value_t While::compile_jit(Compiler& c, jit_function_t& F, Type type) const 
 	jit_label_t label_cond = jit_label_undefined;
 	jit_label_t label_end = jit_label_undefined;
 	jit_value_t const_true = JIT_CREATE_CONST(F, JIT_INTEGER, 1);
-	jit_type_t args_types[1] = {jit_type_int};
+	jit_type_t args_types[1] = {JIT_POINTER};
 	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_INTEGER, args_types, 1, 0);
 
 	c.enter_loop(&label_end, &label_cond);
@@ -66,5 +66,5 @@ jit_value_t While::compile_jit(Compiler& c, jit_function_t& F, Type type) const 
 
 	c.leave_loop();
 
-	return JIT_CREATE_CONST(F, JIT_INTEGER, (long int) LSNull::null_var);
+	return JIT_CREATE_CONST_POINTER(F, LSNull::null_var);
 }

--- a/parser/value/AbsoluteValue.cpp
+++ b/parser/value/AbsoluteValue.cpp
@@ -25,8 +25,8 @@ jit_value_t AbsoluteValue::compile_jit(Compiler& c, jit_function_t& F, Type type
 
 	jit_value_t ex = expression->compile_jit(c, F, Type::POINTER);
 
-	jit_type_t args_types[2] = {jit_type_int};
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_int, args_types, 1, 0);
+	jit_type_t args_types[2] = {JIT_POINTER};
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_POINTER, args_types, 1, 0);
 
 	return jit_insn_call_native(F, "abso", (void*) abso, sig, &ex, 1, JIT_CALL_NOTHROW);
 }

--- a/parser/value/Array.cpp
+++ b/parser/value/Array.cpp
@@ -95,14 +95,14 @@ void LSArray_push(LSArray* array, LSValue* value) {
 
 jit_value_t Array::compile_jit(Compiler& c, jit_function_t& F, Type) const {
 
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_int, {}, 0, 0);
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_POINTER, {}, 0, 0);
 	jit_value_t array = jit_insn_call_native(F, "new", (void*) LSArray_create, sig, {}, 0, JIT_CALL_NOTHROW);
 
 	for (Value* val : expressions) {
 
 		jit_value_t v = val->compile_jit(c, F, Type::POINTER);
 
-		jit_type_t args[2] = {JIT_INTEGER, JIT_INTEGER};
+		jit_type_t args[2] = {JIT_POINTER, JIT_POINTER};
 		jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_void, args, 2, 0);
 		jit_value_t args_v[] = {array, v};
 		jit_insn_call_native(F, "push", (void*) LSArray_push, sig, args_v, 2, JIT_CALL_NOTHROW);

--- a/parser/value/ArrayAccess.cpp
+++ b/parser/value/ArrayAccess.cpp
@@ -62,7 +62,7 @@ bool ArrayAccess::array_access_will_take(SemanticAnalyser* analyser, const unsig
 	return false;
 }
 
-LSValue* access(LSArray* array, LSValue* key) {
+LSValue* access_temp(LSArray* array, LSValue* key) {
 	return array->at(key);
 }
 
@@ -84,17 +84,17 @@ jit_value_t ArrayAccess::compile_jit(Compiler& c, jit_function_t& F, Type) const
 
 	if (key2 == nullptr) {
 
-		jit_type_t args_types[2] = {jit_type_int, jit_type_int};
-		jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_int, args_types, 2, 0);
+		jit_type_t args_types[2] = {JIT_POINTER, JIT_POINTER};
+		jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_POINTER, args_types, 2, 0);
 
 		jit_value_t k = key->compile_jit(c, F, Type::POINTER);
 		jit_value_t args[] = {a, k};
-		return jit_insn_call_native(F, "access", (void*) access, sig, args, 2, JIT_CALL_NOTHROW);
+		return jit_insn_call_native(F, "access", (void*) access_temp, sig, args, 2, JIT_CALL_NOTHROW);
 
 	} else {
 
-		jit_type_t args_types[3] = {jit_type_int, jit_type_int, jit_type_int};
-		jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_int, args_types, 3, 0);
+		jit_type_t args_types[3] = {JIT_POINTER, JIT_POINTER, JIT_POINTER};
+		jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_POINTER, args_types, 3, 0);
 
 		jit_value_t start = key->compile_jit(c, F, Type::POINTER);
 		jit_value_t end = key2->compile_jit(c, F, Type::POINTER);
@@ -107,8 +107,8 @@ jit_value_t ArrayAccess::compile_jit_l(Compiler& c, jit_function_t& F, Type) con
 
 	jit_value_t a = array->compile_jit(c, F, Type::POINTER);
 
-	jit_type_t args_types[2] = {jit_type_int, jit_type_int};
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_int, args_types, 2, 0);
+	jit_type_t args_types[2] = {JIT_POINTER, JIT_POINTER};
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_POINTER, args_types, 2, 0);
 
 	jit_value_t k = key->compile_jit(c, F, Type::POINTER);
 	jit_value_t args[] = {a, k};

--- a/parser/value/Boolean.cpp
+++ b/parser/value/Boolean.cpp
@@ -22,7 +22,7 @@ jit_value_t Boolean::compile_jit(Compiler& c, jit_function_t& F, Type req_type) 
 
 	if (req_type.nature == Nature::POINTER) {
 		LSBoolean* b = new LSBoolean(value);
-		return JIT_CREATE_CONST(F, JIT_INTEGER, (long int) b);
+		return JIT_CREATE_CONST_POINTER(F, b);
 	} else {
 		return JIT_CREATE_CONST(F, JIT_INTEGER, value);
 	}

--- a/parser/value/Expression.cpp
+++ b/parser/value/Expression.cpp
@@ -451,6 +451,8 @@ jit_value_t Expression::compile_jit(Compiler& c, jit_function_t& F, Type req_typ
 			break;
 		}
 		case TokenType::POWER: {
+			if (req_type.nature == Nature::POINTER)
+				use_jit_func = false;
 			jit_func = &jit_insn_pow;
 			ls_func = (void*) &jit_pow;
 			break;
@@ -503,7 +505,6 @@ jit_value_t Expression::compile_jit(Compiler& c, jit_function_t& F, Type req_typ
 
 		jit_value_t x = v1->compile_jit(c, F, Type::NEUTRAL);
 		jit_value_t y = v2->compile_jit(c, F, Type::NEUTRAL);
-
 		/*
 		jit_value_t is_int = jit_insn_eq(F,
 			jit_insn_and(F, x, jit_value_create_nint_constant(F, jit_type_int, 2147483648)),
@@ -534,8 +535,8 @@ jit_value_t Expression::compile_jit(Compiler& c, jit_function_t& F, Type req_typ
 
 //		cout << "expression pointers" << endl;
 
-		jit_type_t args_types[2] = {JIT_INTEGER, JIT_INTEGER};
-		jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_INTEGER, args_types, 2, 0);
+		jit_type_t args_types[2] = {JIT_POINTER, JIT_POINTER};
+		jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_POINTER, args_types, 2, 0);
 
 		if (args.size() == 0) {
 			args.push_back(v1->compile_jit(c, F, v1_conv));
@@ -548,3 +549,4 @@ jit_value_t Expression::compile_jit(Compiler& c, jit_function_t& F, Type req_typ
 		return v;
 	}
 }
+

--- a/parser/value/Function.cpp
+++ b/parser/value/Function.cpp
@@ -125,14 +125,17 @@ jit_value_t Function::compile_jit(Compiler& c, jit_function_t& F, Type req_type)
 			t = type.getArgumentType(i);
 		}
 //		cout << "func arg: " << t << endl;
-		params.push_back(t.raw_type == RawType::FLOAT ? JIT_FLOAT : JIT_INTEGER);
+		params.push_back(t.nature == Nature::POINTER ? JIT_POINTER :
+				(t.raw_type == RawType::FLOAT) ? JIT_FLOAT :
+				(t.raw_type == RawType::LONG) ? JIT_INTEGER_LONG :
+				JIT_INTEGER);
 	}
 
-	jit_type_t return_type =
-			(type.getReturnType().raw_type == RawType::LONG
-					or type.getReturnType().raw_type == RawType::FUNCTION) ? JIT_INTEGER_LONG :
+	jit_type_t return_type = type.getReturnType().nature == Nature::POINTER ? JIT_POINTER : (
+			(type.getReturnType().raw_type == RawType::FUNCTION) ? JIT_POINTER :
+			(type.getReturnType().raw_type == RawType::LONG) ? JIT_INTEGER_LONG :
 			(type.getReturnType().raw_type == RawType::FLOAT) ? JIT_FLOAT :
-			JIT_INTEGER;
+			JIT_INTEGER);
 
 	jit_type_t signature = jit_type_create_signature(jit_abi_cdecl, return_type, params.data(), arg_count, 1);
 
@@ -149,9 +152,9 @@ jit_value_t Function::compile_jit(Compiler& c, jit_function_t& F, Type req_type)
 	if (req_type.nature == Nature::POINTER) {
 //		cout << "create function pointer " << endl;
 		LSFunction* fo = new LSFunction(f);
-		return JIT_CREATE_CONST(F, JIT_INTEGER, (long int) fo);
+		return JIT_CREATE_CONST_POINTER(F, fo);
 	} else {
 //		cout << "create function value " << endl;
-		return JIT_CREATE_CONST_LONG(F, JIT_INTEGER_LONG, (long) f);
+		return JIT_CREATE_CONST_POINTER(F, f);
 	}
 }

--- a/parser/value/If.cpp
+++ b/parser/value/If.cpp
@@ -55,7 +55,7 @@ int is_true(LSValue* v) {
 
 jit_value_t If::compile_jit(Compiler& c, jit_function_t& F, Type req_type) const {
 
-	jit_value_t res = jit_value_create(F, JIT_INTEGER);
+	jit_value_t res = jit_value_create(F, JIT_INTEGER_LONG);
 	jit_label_t label_else = jit_label_undefined;
 	jit_label_t label_end = jit_label_undefined;
 
@@ -65,8 +65,8 @@ jit_value_t If::compile_jit(Compiler& c, jit_function_t& F, Type req_type) const
 
 		jit_value_t const_true = jit_value_create_nint_constant(F, jit_type_int, 1);
 
-		jit_type_t args_types[1] = {jit_type_int};
-		jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_int, args_types, 1, 0);
+		jit_type_t args_types[1] = {JIT_POINTER};
+		jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_INTEGER, args_types, 1, 0);
 		jit_value_t cond_bool = jit_insn_call_native(F, "is_true", (void*) is_true, sig, &cond, 1, JIT_CALL_NOTHROW);
 
 		jit_value_t cmp = inversed ?

--- a/parser/value/Nulll.cpp
+++ b/parser/value/Nulll.cpp
@@ -20,7 +20,7 @@ jit_value_t Nulll::compile_jit(Compiler& c, jit_function_t& F, Type req_type) co
 
 	if (req_type.nature == Nature::POINTER) {
 		LSNull* n = new LSNull();
-		return JIT_CREATE_CONST(F, JIT_INTEGER, (long int) n);
+		return JIT_CREATE_CONST_POINTER(F, n);
 	} else {
 		return JIT_CREATE_CONST(F, JIT_INTEGER, 0);
 	}

--- a/parser/value/Number.cpp
+++ b/parser/value/Number.cpp
@@ -31,10 +31,9 @@ jit_value_t Number::compile_jit(Compiler& c, jit_function_t& F, Type req_type) c
 	if (req_type.nature == Nature::POINTER) {
 
 		LSNumber* n = new LSNumber(value);
-		return JIT_CREATE_CONST(F, JIT_INTEGER, (long int) n);
+		return JIT_CREATE_CONST_POINTER(F, n);
 
 	} else {
-
 		bool isfloat = type.raw_type == RawType::FLOAT;
 		jit_type_t type = isfloat ? JIT_FLOAT : JIT_INTEGER;
 

--- a/parser/value/Object.cpp
+++ b/parser/value/Object.cpp
@@ -35,13 +35,13 @@ void push_object(LSObject* o, LSString* k, LSValue* v) {
 jit_value_t Object::compile_jit(Compiler& c, jit_function_t& F, Type req_type) const {
 
 	LSObject* o = new LSObject();
-	jit_value_t object = jit_value_create_nint_constant(F, jit_type_int, (long int) o);
+	jit_value_t object = JIT_CREATE_CONST_POINTER(F, o);
 
-	jit_type_t args[3] = {jit_type_int, jit_type_int, jit_type_int};
+	jit_type_t args[3] = {JIT_POINTER, JIT_POINTER, JIT_POINTER};
 	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_void, args, 3, 0);
 
 	for (unsigned i = 0; i < keys.size(); ++i) {
-		jit_value_t k = jit_value_create_nint_constant(F, jit_type_int, (long int) new LSString(keys.at(i)->token->content));
+		jit_value_t k = JIT_CREATE_CONST_POINTER(F, new LSString(keys.at(i)->token->content));
 		jit_value_t v = values[i]->compile_jit(c, F, Type::POINTER);
 		jit_value_t args[] = {object, k, v};
 		jit_insn_call_native(F, "push", (void*) push_object, sig, args, 3, JIT_CALL_NOTHROW);

--- a/parser/value/ObjectAccess.cpp
+++ b/parser/value/ObjectAccess.cpp
@@ -39,10 +39,10 @@ jit_value_t ObjectAccess::compile_jit(Compiler& c, jit_function_t& F, Type req_t
 
 	jit_value_t o = object->compile_jit(c, F, Type::POINTER);
 
-	jit_type_t args_types[2] = {jit_type_int, jit_type_int};
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_int, args_types, 2, 0);
+	jit_type_t args_types[2] = {JIT_POINTER, JIT_POINTER};
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_POINTER, args_types, 2, 0);
 
-	jit_value_t k = jit_value_create_nint_constant(F, jit_type_int, (long int) new LSString(field));
+	jit_value_t k = JIT_CREATE_CONST_POINTER(F,  new LSString(field));
 	jit_value_t args[] = {o, k};
 	return jit_insn_call_native(F, "access", (void*) object_access, sig, args, 2, JIT_CALL_NOTHROW);
 }
@@ -51,10 +51,10 @@ jit_value_t ObjectAccess::compile_jit_l(Compiler& c, jit_function_t& F, Type typ
 
 	jit_value_t o = object->compile_jit(c, F, Type::POINTER);
 
-	jit_type_t args_types[2] = {jit_type_int, jit_type_int};
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_int, args_types, 2, 0);
+	jit_type_t args_types[2] = {JIT_POINTER, JIT_POINTER};
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_POINTER, args_types, 2, 0);
 
-	jit_value_t k = jit_value_create_nint_constant(F, jit_type_int, (long int) new LSString(field));
+	jit_value_t k = JIT_CREATE_CONST_POINTER(F,  new LSString(field));
 	jit_value_t args[] = {o, k};
 	return jit_insn_call_native(F, "access_l", (void*) object_access_l, sig, args, 2, JIT_CALL_NOTHROW);
 }

--- a/parser/value/PostfixExpression.cpp
+++ b/parser/value/PostfixExpression.cpp
@@ -26,8 +26,8 @@ extern LSValue* jit_dec(LSValue*);
 
 jit_value_t PostfixExpression::compile_jit(Compiler& c, jit_function_t& F, Type	req_type) const {
 
-	jit_type_t args_types[1] = {jit_type_int};
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_int, args_types, 1, 0);
+	jit_type_t args_types[1] = {JIT_POINTER};
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_POINTER, args_types, 1, 0);
 	vector<jit_value_t> args;
 
 	void* func = nullptr;
@@ -38,7 +38,7 @@ jit_value_t PostfixExpression::compile_jit(Compiler& c, jit_function_t& F, Type	
 			if (expression->type.nature == Nature::VALUE) {
 				jit_value_t x = expression->compile_jit(c, F, Type::NEUTRAL);
 				jit_value_t ox = jit_insn_load(F, x);
-				jit_value_t y = JIT_CREATE_CONST(F, jit_type_int, 1);
+				jit_value_t y = JIT_CREATE_CONST(F, JIT_INTEGER, 1);
 				jit_value_t sum = jit_insn_add(F, x, y);
 				jit_insn_store(F, x, sum);
 				if (req_type.nature == Nature::POINTER) {
@@ -55,7 +55,7 @@ jit_value_t PostfixExpression::compile_jit(Compiler& c, jit_function_t& F, Type	
 			if (expression->type.nature == Nature::VALUE) {
 				jit_value_t x = expression->compile_jit(c, F, Type::NEUTRAL);
 				jit_value_t ox = jit_insn_load(F, x);
-				jit_value_t y = JIT_CREATE_CONST(F, jit_type_int, 1);
+				jit_value_t y = JIT_CREATE_CONST(F, JIT_INTEGER, 1);
 				jit_value_t sum = jit_insn_sub(F, x, y);
 				jit_insn_store(F, x, sum);
 				if (req_type.nature == Nature::POINTER) {

--- a/parser/value/PrefixExpression.cpp
+++ b/parser/value/PrefixExpression.cpp
@@ -32,8 +32,8 @@ LSValue* jit_pre_tilde(LSValue* v) {
 
 jit_value_t PrefixExpression::compile_jit(Compiler& c, jit_function_t& F, Type req_type) const {
 
-	jit_type_t args_types[1] = {jit_type_int};
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_int, args_types, 1, 0);
+	jit_type_t args_types[1] = {JIT_POINTER};
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_POINTER, args_types, 1, 0);
 	vector<jit_value_t> args;
 
 	void* func = nullptr;
@@ -43,7 +43,7 @@ jit_value_t PrefixExpression::compile_jit(Compiler& c, jit_function_t& F, Type r
 		case TokenType::PLUS_PLUS: {
 			if (expression->type.nature == Nature::VALUE) {
 				jit_value_t x = expression->compile_jit(c, F, Type::NEUTRAL);
-				jit_value_t y = jit_value_create_nint_constant(F, jit_type_int, 1);
+				jit_value_t y = JIT_CREATE_CONST(F, JIT_INTEGER, 1);
 				jit_value_t sum = jit_insn_add(F, x, y);
 				jit_insn_store(F, x, sum);
 				if (req_type.nature == Nature::POINTER) {
@@ -59,7 +59,7 @@ jit_value_t PrefixExpression::compile_jit(Compiler& c, jit_function_t& F, Type r
 		case TokenType::MINUS_MINUS: {
 			if (expression->type.nature == Nature::VALUE) {
 				jit_value_t x = expression->compile_jit(c, F, Type::NEUTRAL);
-				jit_value_t y = jit_value_create_nint_constant(F, jit_type_int, 1);
+				jit_value_t y = JIT_CREATE_CONST(F, JIT_INTEGER, 1);
 				jit_value_t sum = jit_insn_sub(F, x, y);
 				jit_insn_store(F, x, sum);
 				if (req_type.nature == Nature::POINTER) {
@@ -110,17 +110,17 @@ jit_value_t PrefixExpression::compile_jit(Compiler& c, jit_function_t& F, Type r
 			if (VariableValue* vv = dynamic_cast<VariableValue*>(expression)) {
 
 				if (vv->name->content == "Number") {
-					jit_value_t n = jit_value_create_nint_constant(F, JIT_INTEGER, 0);
+					jit_value_t n = JIT_CREATE_CONST(F, JIT_INTEGER, 0);
 					if (req_type.nature == Nature::POINTER) {
 						return VM::value_to_pointer(F, n, Type::INTEGER);
 					}
 					return n;
 				}
 				if (vv->name->content == "String") {
-					return jit_value_create_nint_constant(F, JIT_INTEGER, (long int) new LSString(""));
+					return JIT_CREATE_CONST_POINTER(F,  new LSString(""));
 				}
 				if (vv->name->content == "Array") {
-					return jit_value_create_nint_constant(F, JIT_INTEGER, (long int) new LSArray());
+					return JIT_CREATE_CONST_POINTER(F,  new LSArray());
 				}
 			}
 
@@ -130,7 +130,7 @@ jit_value_t PrefixExpression::compile_jit(Compiler& c, jit_function_t& F, Type r
 						if (fc->arguments.size() > 0) {
 							return fc->arguments[0]->compile_jit(c, F, Type::POINTER);
 						} else {
-							jit_value_t n = jit_value_create_nint_constant(F, JIT_INTEGER, 0);
+							jit_value_t n = JIT_CREATE_CONST(F, JIT_INTEGER, 0);
 							if (req_type.nature == Nature::POINTER) {
 								return VM::value_to_pointer(F, n, Type::INTEGER);
 							}
@@ -141,10 +141,10 @@ jit_value_t PrefixExpression::compile_jit(Compiler& c, jit_function_t& F, Type r
 						if (fc->arguments.size() > 0) {
 							return fc->arguments[0]->compile_jit(c, F, Type::POINTER);
 						}
-						return jit_value_create_nint_constant(F, JIT_INTEGER, (long int) new LSString(""));
+						return JIT_CREATE_CONST_POINTER(F, new LSString(""));
 					}
 					if (vv->name->content == "Array") {
-						return jit_value_create_nint_constant(F, JIT_INTEGER, (long int) new LSArray());
+						return JIT_CREATE_CONST_POINTER(F, new LSArray());
 					}
 				}
 			}

--- a/parser/value/String.cpp
+++ b/parser/value/String.cpp
@@ -22,5 +22,5 @@ void String::analyse(SemanticAnalyser* analyser, const Type) {
 jit_value_t String::compile_jit(Compiler&, jit_function_t& F, Type type) const {
 
 	LSString* s = new LSString(value);
-	return JIT_CREATE_CONST(F, JIT_INTEGER, (long) s);
+	return JIT_CREATE_CONST_POINTER(F,  s);
 }

--- a/parser/value/VariableValue.cpp
+++ b/parser/value/VariableValue.cpp
@@ -61,27 +61,27 @@ jit_value_t VariableValue::compile_jit(Compiler&, jit_function_t& F, Type req_ty
 //	cout << "req type : " << req_type << endl;
 
 	if (name->content == "+") {
-		return jit_value_create_nint_constant(F, jit_type_int, (long int) new LSFunction((void*) &plus_function_int));
+		return JIT_CREATE_CONST_POINTER(F, new LSFunction((void*) &plus_function_int));
 	}
 	if (name->content == "-") {
-		return jit_value_create_nint_constant(F, jit_type_int, (long int) new LSFunction((void*) &minus_function_int));
+		return JIT_CREATE_CONST_POINTER(F, new LSFunction((void*) &minus_function_int));
 	}
 	if (name->content == "*") {
-		return jit_value_create_nint_constant(F, jit_type_int, (long int) new LSFunction((void*) &mul_function_int));
+		return JIT_CREATE_CONST_POINTER(F, new LSFunction((void*) &mul_function_int));
 	}
 	if (name->content == "/") {
-		return jit_value_create_nint_constant(F, jit_type_int, (long int) new LSFunction((void*) &div_function_int));
+		return JIT_CREATE_CONST_POINTER(F, new LSFunction((void*) &div_function_int));
 	}
 	if (name->content == "^") {
-		return jit_value_create_nint_constant(F, jit_type_int, (long int) new LSFunction((void*) &pow_function_int));
+		return JIT_CREATE_CONST_POINTER(F, new LSFunction((void*) &pow_function_int));
 	}
 	if (name->content == "%") {
-		return jit_value_create_nint_constant(F, jit_type_int, (long int) new LSFunction((void*) &mod_function_int));
+		return JIT_CREATE_CONST_POINTER(F, new LSFunction((void*) &mod_function_int));
 	}
 
 	if (var->scope == VarScope::INTERNAL) {
 
-		//cout << "internal" << endl;
+//		cout << "internal" << endl;
 
 		jit_value_t v = internals[name->content];
 		if (var->type.nature != Nature::POINTER and req_type.nature == Nature::POINTER) {

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -480,7 +480,7 @@ void Test::test(string code, string result) {
 
 		// Create function signature and object. int (*)(int)
 		jit_type_t params[0] = {};
-		jit_type_t signature = jit_type_create_signature(jit_abi_cdecl, jit_type_int, params, 0, 1);
+		jit_type_t signature = jit_type_create_signature(jit_abi_cdecl, JIT_POINTER, params, 0, 1);
 		jit_function_t F = jit_function_create(jit_context, signature);
 
 		program->compile_jit(c, F, context, false);

--- a/vm/VM.cpp
+++ b/vm/VM.cpp
@@ -92,6 +92,8 @@ string VM::execute(const string code, string ctx, ExecMode mode) {
 
 	typedef LSValue* (*FF)();
 	FF fun = (FF) jit_function_to_closure(F);
+	double comp_time = (double(clock() - begin) / CLOCKS_PER_SEC) * 1000;
+
 
 	/*
 	 * Execute
@@ -102,8 +104,6 @@ string VM::execute(const string code, string ctx, ExecMode mode) {
 
 	long exe_time_ns = chrono::duration_cast<chrono::nanoseconds>(end - start).count();
 	double exe_time_ms = (((double) exe_time_ns / 1000) / 1000);
-	double comp_time = (double(clock() - begin) / CLOCKS_PER_SEC) * 1000;
-
 	/*
 	 * Return results
 	 */

--- a/vm/VM.cpp
+++ b/vm/VM.cpp
@@ -82,7 +82,7 @@ string VM::execute(const string code, string ctx, ExecMode mode) {
 	jit_context_build_start(jit_context);
 
 	jit_type_t params[0] = {};
-	jit_type_t signature = jit_type_create_signature(jit_abi_cdecl, jit_type_int, params, 0, 1);
+	jit_type_t signature = jit_type_create_signature(jit_abi_cdecl, JIT_INTEGER_LONG, params, 0, 1);
 	jit_function_t F = jit_function_create(jit_context, signature);
 
 	program->compile_jit(c, F, context, mode != ExecMode::NORMAL);
@@ -193,14 +193,12 @@ jit_value_t VM::value_to_pointer(jit_function_t& F, jit_value_t& v, Type type) {
 	}
 
 	jit_type_t args_types[1] = {
-		(type.raw_type == RawType::FUNCTION or type.raw_type == RawType::LONG)
-		? JIT_INTEGER_LONG :
-		(type.raw_type == RawType::FLOAT) ?
-		JIT_FLOAT :
-		JIT_INTEGER
+		(type.raw_type == RawType::FUNCTION) ? JIT_POINTER :
+		(type.raw_type == RawType::LONG) ? JIT_INTEGER_LONG :
+		(type.raw_type == RawType::FLOAT) ?	JIT_FLOAT :
+			JIT_INTEGER
 	};
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_INTEGER, args_types, 1, 0);
-
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_POINTER, args_types, 1, 0);
 	return jit_insn_call_native(F, "convert", (void*) fun, sig, &v, 1, JIT_CALL_NOTHROW);
 }
 /*

--- a/vm/VM.hpp
+++ b/vm/VM.hpp
@@ -21,10 +21,12 @@ using namespace std;
 #define JIT_INTEGER jit_type_int
 #define JIT_INTEGER_LONG jit_type_long
 #define JIT_FLOAT jit_type_float64
+#define JIT_POINTER jit_type_void_ptr
 
 #define JIT_CREATE_CONST jit_value_create_nint_constant
 #define JIT_CREATE_CONST_LONG jit_value_create_long_constant
 #define JIT_CREATE_CONST_FLOAT jit_value_create_float64_constant
+#define JIT_CREATE_CONST_POINTER(F, X)  jit_value_create_constant((F),new jit_constant_t{JIT_POINTER,{(X)}})
 
 enum class ExecMode {
 	NORMAL, TOP_LEVEL, COMMAND_JSON

--- a/vm/standard/NumberSTD.cpp
+++ b/vm/standard/NumberSTD.cpp
@@ -109,7 +109,7 @@ LSNumber* number_randInt(const LSNumber* min, const LSNumber* max) {
 }
 
 LSNumber* number_round(const LSNumber* number) {
-	return new LSNumber(round(number->value));
+	return LSNumber::get(round(number->value));
 }
 
 LSNumber* number_signum(const LSNumber* x) {


### PR DESCRIPTION
Also bypasses the functions :
`jit_insn_pow` `jit_insn_round` and `jit_insn_cos`
As they were not working for me (always returned 0)
