### PR TITLE
Overloading function operators and various fixes

### DIFF
--- a/parser/instruction/VariableDeclaration.cpp
+++ b/parser/instruction/VariableDeclaration.cpp
@@ -78,7 +78,7 @@ jit_value_t VariableDeclaration::compile_jit(Compiler& c, jit_function_t& F, Typ
 
 //			cout << "add global var : " << variables[i] << endl;
 
-			jit_value_t var = jit_value_create(F, JIT_INTEGER_LONG);
+			jit_value_t var = jit_value_create(F, JIT_POINTER);
 			globals.insert(pair<string, jit_value_t>(variables[i], var));
 
 			if (i < expressions.size()) {
@@ -101,7 +101,12 @@ jit_value_t VariableDeclaration::compile_jit(Compiler& c, jit_function_t& F, Typ
 			}
 		} else {
 
-			jit_value_t var = jit_value_create(F, JIT_INTEGER);
+			jit_value_t var = jit_value_create(F, JIT_POINTER);
+//			jit_value_t var = jit_value_create(F, i < expressions.size() ? JIT_POINTER :
+//					expressions[i]->type.nature != Nature::VALUE ? JIT_POINTER :
+//					expressions[i]->type.raw_type == RawType::FLOAT ? JIT_FLOAT :
+//					expressions[i]->type.raw_type == RawType::LONG ? JIT_INTEGER_LONG :
+//					JIT_INTEGER);
 			locals.insert(pair<string, jit_value_t>(variables[i], var));
 
 			if (i < expressions.size()) {

--- a/parser/semantic/SemanticAnalyser.cpp
+++ b/parser/semantic/SemanticAnalyser.cpp
@@ -41,7 +41,7 @@ void SemanticAnalyser::analyse(Program* program, Context* context) {
 
 	Type op_type = Type(RawType::FUNCTION, Nature::POINTER);
 	op_type.setArgumentType(0, Type::INTEGER);
-	op_type.setArgumentType(0, Type::INTEGER);
+	op_type.setArgumentType(1, Type::INTEGER);
 	op_type.setReturnType(Type::INTEGER);
 	add_var("+", op_type, nullptr);
 	add_var("-", op_type, nullptr);

--- a/parser/semantic/SemanticAnalyser.cpp
+++ b/parser/semantic/SemanticAnalyser.cpp
@@ -30,6 +30,12 @@ void SemanticVar::will_take(SemanticAnalyser* analyser, unsigned pos, const Type
 	}
 }
 
+extern LSValue* jit_add(LSValue* x, LSValue* y);
+extern LSValue* jit_sub(LSValue* x, LSValue* y);
+extern LSValue* jit_mul(LSValue* x, LSValue* y);
+extern LSValue* jit_div(LSValue* x, LSValue* y);
+extern LSValue* jit_pow(LSValue* x, LSValue* y);
+extern LSValue* jit_mod(LSValue* x, LSValue* y);
 void SemanticAnalyser::analyse(Program* program, Context* context) {
 
 	this->program = program;
@@ -40,19 +46,25 @@ void SemanticAnalyser::analyse(Program* program, Context* context) {
 	}
 
 	Type op_type = Type(RawType::FUNCTION, Nature::POINTER);
-	op_type.setArgumentType(0, Type::INTEGER);
-	op_type.setArgumentType(1, Type::INTEGER);
-	op_type.setReturnType(Type::INTEGER);
+	op_type.setArgumentType(0, Type::POINTER);
+	op_type.setArgumentType(1, Type::POINTER);
+	op_type.setReturnType(Type::POINTER);
+	program->system_vars.insert(pair<string, LSValue*>("+", new LSFunction((void*) &jit_add)));
 	add_var("+", op_type, nullptr);
+	program->system_vars.insert(pair<string, LSValue*>("-", new LSFunction((void*) &jit_sub)));
 	add_var("-", op_type, nullptr);
+	program->system_vars.insert(pair<string, LSValue*>("*", new LSFunction((void*) &jit_mul)));
 	add_var("*", op_type, nullptr);
+	program->system_vars.insert(pair<string, LSValue*>("/", new LSFunction((void*) &jit_div)));
 	add_var("/", op_type, nullptr);
+	program->system_vars.insert(pair<string, LSValue*>("^", new LSFunction((void*) &jit_pow)));
 	add_var("^", op_type, nullptr);
+	program->system_vars.insert(pair<string, LSValue*>("%", new LSFunction((void*) &jit_mod)));
 	add_var("%", op_type, nullptr);
 
 	Type print_type = Type(RawType::FUNCTION, Nature::POINTER);
 	print_type.setArgumentType(0, Type::VALUE);
-	print_type.setReturnType(Type::STRING);
+	print_type.setReturnType(Type::POINTER);
 	add_var("print", print_type, nullptr);
 
 	NumberSTD().include(this, program);

--- a/parser/value/Expression.cpp
+++ b/parser/value/Expression.cpp
@@ -458,9 +458,6 @@ jit_value_t Expression::compile_jit(Compiler& c, jit_function_t& F, Type req_typ
 			break;
 		}
 		case TokenType::POWER: {
-			if (req_type.nature == Nature::POINTER) {
-				use_jit_func = false;
-			}
 			jit_func = &jit_insn_pow;
 			ls_func = (void*) &jit_pow;
 			break;

--- a/parser/value/FunctionCall.cpp
+++ b/parser/value/FunctionCall.cpp
@@ -137,6 +137,13 @@ void func_print_int(int v) {
 	cout << " >>> " << v << endl;
 }
 
+extern LSValue* jit_add(LSValue* x, LSValue* y);
+extern LSValue* jit_sub(LSValue* x, LSValue* y);
+extern LSValue* jit_mul(LSValue* x, LSValue* y);
+extern LSValue* jit_div(LSValue* x, LSValue* y);
+extern LSValue* jit_pow(LSValue* x, LSValue* y);
+extern LSValue* jit_mod(LSValue* x, LSValue* y);
+
 LSValue* create_float_object_3(double n) {
 	return LSNumber::get(n);
 }
@@ -186,30 +193,14 @@ jit_value_t FunctionCall::compile_jit(Compiler& c, jit_function_t& F, Type req_t
 			jit_value_t v = arguments[0]->compile_jit(c, F, Type::VALUE);
 			res = jit_insn_floor(F, v);
 		} else if (native_func == "round") {
-			if (req_type.nature == Nature::VALUE) {
-				jit_value_t v = arguments[0]->compile_jit(c, F, Type::VALUE);
-				res = jit_insn_round(F, v);
-			} else {
-				vector<jit_value_t> args = { arguments[0]->compile_jit(c, F, Type::POINTER) };
-				vector<jit_type_t> args_types = { JIT_POINTER };
-				jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_POINTER, args_types.data(), 1, 0);
-				res = jit_insn_call_native(F, "round", (void*) &number_round, sig, args.data(), 1, JIT_CALL_NOTHROW);
-				return res;
-			}
+			jit_value_t v = arguments[0]->compile_jit(c, F, Type::VALUE);
+			res = jit_insn_round(F, v);
 		} else if (native_func == "ceil") {
 			jit_value_t v = arguments[0]->compile_jit(c, F, Type::VALUE);
 			res = jit_insn_ceil(F, v);
 		} else if (native_func == "cos") {
-			if (req_type.nature == Nature::VALUE) {
-				jit_value_t v = arguments[0]->compile_jit(c, F, Type::VALUE);
-				res = jit_insn_cos(F, v);
-			} else {
-				vector<jit_value_t> args = { arguments[0]->compile_jit(c, F, Type::POINTER) };
-				vector<jit_type_t> args_types = { JIT_POINTER };
-				jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_POINTER, args_types.data(), 1, 0);
-				res = jit_insn_call_native(F, "round", (void*) &number_cos, sig, args.data(), 1, JIT_CALL_NOTHROW);
-				return res;
-			}
+			jit_value_t v = arguments[0]->compile_jit(c, F, Type::VALUE);
+			res = jit_insn_cos(F, v);
 		} else if (native_func == "sin") {
 			jit_value_t v = arguments[0]->compile_jit(c, F, Type::VALUE);
 			res = jit_insn_sin(F, v);
@@ -225,17 +216,9 @@ jit_value_t FunctionCall::compile_jit(Compiler& c, jit_function_t& F, Type req_t
 			jit_value_t v1 = arguments[0]->compile_jit(c, F, Type::VALUE);
 			res = jit_insn_sqrt(F, v1);
 		} else if (native_func == "pow") {
-			if (req_type.nature == Nature::VALUE) {
-				jit_value_t v1 = arguments[0]->compile_jit(c, F, Type::VALUE);
-				jit_value_t v2 = arguments[1]->compile_jit(c, F, Type::VALUE);
-				res = jit_insn_pow(F, v1, v2);
-			} else {
-				vector<jit_value_t> args = { arguments[0]->compile_jit(c, F, Type::POINTER),arguments[1]->compile_jit(c, F, Type::POINTER) };
-				vector<jit_type_t> args_types = { JIT_POINTER,JIT_POINTER };
-				jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_POINTER, args_types.data(), 2, 0);
-				res = jit_insn_call_native(F, "test", (void*) &number_pow, sig, args.data(), 1, JIT_CALL_NOTHROW);
-				return res;
-			}
+			jit_value_t v1 = arguments[0]->compile_jit(c, F, Type::VALUE);
+			jit_value_t v2 = arguments[1]->compile_jit(c, F, Type::VALUE);
+			res = jit_insn_pow(F, v1, v2);
 		}
 
 		if (req_type.nature == Nature::POINTER && type.nature == Nature::VALUE) {
@@ -253,11 +236,12 @@ jit_value_t FunctionCall::compile_jit(Compiler& c, jit_function_t& F, Type req_t
 		vector<jit_value_t> args = { this_ptr->compile_jit(c, F, Type::POINTER) };
 		vector<jit_type_t> args_types = { JIT_POINTER };
 
-		for (int i = 0; i < arg_count - 1; ++i) {
-			args.push_back(arguments[i]->compile_jit(c, F, function->type.getArgumentType(i)));
-			args_types.push_back(function->type.getArgumentType(i).nature == Nature::POINTER ? JIT_POINTER :
+		for (int i = 1; i < arg_count; ++i) {
+			args.push_back(arguments[i-1]->compile_jit(c, F, function->type.getArgumentType(i)));
+			args_types.push_back(function->type.getArgumentType(i).nature!= Nature::VALUE ? JIT_POINTER :
 				(function->type.getArgumentType(i).raw_type == RawType::FUNCTION)	? JIT_POINTER :
 				(function->type.getArgumentType(i).raw_type == RawType::FLOAT)	? JIT_FLOAT :
+				(function->type.getArgumentType(i).raw_type == RawType::LONG) ? JIT_INTEGER_LONG :
 				JIT_INTEGER);
 		}
 
@@ -269,28 +253,83 @@ jit_value_t FunctionCall::compile_jit(Compiler& c, jit_function_t& F, Type req_t
 
 	VariableValue* f = dynamic_cast<VariableValue*>(function);
 
-	if (f != nullptr && f->name->content == "print") {
+	if (f != nullptr) {
+		if (f->name->content == "print") {
+			jit_value_t v = arguments[0]->compile_jit(c, F, Type::NEUTRAL);
+			if (arguments[0]->type.nature == Nature::VALUE) {
+				jit_type_t args[1] = {JIT_INTEGER};
+				jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_void, args, 1, 0);
+				jit_insn_call_native(F, "lol", (void*) func_print_int, sig, &v, 1, JIT_CALL_NOTHROW);
+			} else {
+				jit_type_t args[1] = {JIT_POINTER};
+				jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_void, args, 1, 0);
+				jit_insn_call_native(F, "lol", (void*) func_print, sig, &v, 1, JIT_CALL_NOTHROW);
+			}
 
-		jit_value_t v = arguments[0]->compile_jit(c, F, Type::NEUTRAL);
-
-		if (arguments[0]->type.nature == Nature::VALUE) {
-			jit_type_t args[1] = {JIT_INTEGER};
-			jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_void, args, 1, 0);
-			jit_insn_call_native(F, "lol", (void*) func_print_int, sig, &v, 1, JIT_CALL_NOTHROW);
-		} else {
-			jit_type_t args[1] = {JIT_POINTER};
-			jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_void, args, 1, 0);
-			jit_insn_call_native(F, "lol", (void*) func_print, sig, &v, 1, JIT_CALL_NOTHROW);
+			return JIT_CREATE_CONST_POINTER(F, LSNull::null_var);
+		}
+		jit_value_t (*jit_func)(jit_function_t, jit_value_t, jit_value_t) = nullptr;
+		void* ls_func = nullptr;
+		if (f->name->content == "+") {
+			if (arguments[0]->type.nature == Nature::VALUE and arguments[1]->type.nature == Nature::VALUE) {
+				jit_func = &jit_insn_add;
+			} else {
+				ls_func = (void*) &jit_add;
+			}
+		} else if (f->name->content == "-") {
+			if (arguments[0]->type.nature == Nature::VALUE and arguments[1]->type.nature == Nature::VALUE) {
+				jit_func = &jit_insn_sub;
+			} else {
+				ls_func = (void*) &jit_sub;
+			}
+		} else if (f->name->content == "*") {
+			if (arguments[0]->type.nature == Nature::VALUE and arguments[1]->type.nature == Nature::VALUE) {
+				jit_func = &jit_insn_mul;
+			} else {
+				ls_func = (void*) &jit_mul;
+			}
+		} else if (f->name->content == "/") {
+			if (arguments[0]->type.nature == Nature::VALUE and arguments[1]->type.nature == Nature::VALUE) {
+				jit_func = &jit_insn_div;
+			} else {
+				ls_func = (void*) &jit_div;
+			}
+		} else if (f->name->content == "^") {
+			if (arguments[0]->type.nature == Nature::VALUE and arguments[1]->type.nature == Nature::VALUE) {
+				jit_func = &jit_insn_pow;
+			} else {
+				ls_func = (void*) &jit_pow;
+			}
+		} else if (f->name->content == "%") {
+			if (arguments[0]->type.nature == Nature::VALUE and arguments[1]->type.nature == Nature::VALUE) {
+				jit_func = &jit_insn_rem;
+			} else {
+				ls_func = (void*) &jit_mod;
+			}
+		}
+		if (jit_func != nullptr) {
+			jit_value_t v0 = arguments[0]->compile_jit(c, F, Type::NEUTRAL);
+			jit_value_t v1 = arguments[1]->compile_jit(c, F, Type::NEUTRAL);
+			jit_value_t ret = jit_func(F,v0,v1);
+			if (req_type.nature == Nature::POINTER) {
+				return VM::value_to_pointer(F, ret, type);
+			}
+			return ret;
+		}
+		if (ls_func != nullptr) {
+			jit_value_t v[2] = {arguments[0]->compile_jit(c, F, Type::POINTER), arguments[1]->compile_jit(c, F, Type::POINTER)};
+			jit_type_t args[2] = {JIT_POINTER, JIT_POINTER};
+			jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_POINTER, args, 2, 0);
+			return jit_insn_call_native(F, "op_pointer", ls_func, sig, v, 2, JIT_CALL_NOTHROW);
 		}
 
-		return JIT_CREATE_CONST_POINTER(F, LSNull::null_var);
 	}
 
 	vector<jit_value_t> fun;
 
 	if (function->type.nature == Nature::POINTER) {
 		jit_value_t fun_addr = function->compile_jit(c, F, Type::NEUTRAL);
-		fun.push_back(jit_insn_load_relative(F, fun_addr, 8, jit_type_void_ptr));
+		fun.push_back(jit_insn_load_relative(F, fun_addr, 8, JIT_POINTER));
 	} else {
 		fun.push_back(function->compile_jit(c, F, Type::NEUTRAL));
 	}
@@ -301,21 +340,20 @@ jit_value_t FunctionCall::compile_jit(Compiler& c, jit_function_t& F, Type req_t
 
 	for (int i = 0; i < arg_count; ++i) {
 		args.push_back(arguments[i]->compile_jit(c, F, function->type.getArgumentType(i)));
-		args_types.push_back(function->type.getArgumentType(i).nature == Nature::POINTER ? JIT_POINTER :
-				(function->type.getArgumentType(i).raw_type == RawType::FUNCTION)	? JIT_POINTER :
-				(function->type.getArgumentType(i).raw_type == RawType::FLOAT)	? JIT_FLOAT :
+		args_types.push_back(function->type.getArgumentType(i).nature != Nature::VALUE ? JIT_POINTER :
+				(function->type.getArgumentType(i).raw_type == RawType::FUNCTION) ? JIT_POINTER :
+				(function->type.getArgumentType(i).raw_type == RawType::FLOAT) ? JIT_FLOAT :
+				(function->type.getArgumentType(i).raw_type == RawType::LONG) ? JIT_INTEGER_LONG :
 				JIT_INTEGER);
 	}
 
 	//cout << "function call return type : " << info << endl;
 
-	jit_type_t return_type =
-		type.nature == Nature::VALUE ? (
+	jit_type_t return_type = type.nature != Nature::VALUE ? JIT_POINTER :
 			(type.raw_type == RawType::FUNCTION) ? JIT_POINTER :
 			(type.raw_type == RawType::LONG) ? JIT_INTEGER_LONG :
 			(type.raw_type == RawType::FLOAT) ? JIT_FLOAT :
-			JIT_INTEGER)
-		: JIT_POINTER;
+			JIT_INTEGER;
 
 	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, return_type, args_types.data(), arg_count, 0);
 

--- a/parser/value/VariableValue.cpp
+++ b/parser/value/VariableValue.cpp
@@ -34,80 +34,11 @@ extern map<string, jit_value_t> internals;
 extern map<string, jit_value_t> globals;
 extern map<string, jit_value_t> locals;
 
-extern LSValue* jit_add(LSValue* x, LSValue* y);
-extern LSValue* jit_sub(LSValue* x, LSValue* y);
-extern LSValue* jit_mul(LSValue* x, LSValue* y);
-extern LSValue* jit_div(LSValue* x, LSValue* y);
-extern LSValue* jit_pow(LSValue* x, LSValue* y);
-extern LSValue* jit_mod(LSValue* x, LSValue* y);
-
-
-int plus_function_int(int x, int y) {
-	return x + y;
-}
-int minus_function_int(int x, int y) {
-	return x - y;
-}
-int mul_function_int(int x, int y) {
-	return x * y;
-}
-int div_function_int(int x, int y) {
-	return x / y;
-}
-int pow_function_int(int x, int y) {
-	return pow(x, y);
-}
-int mod_function_int(int x, int y) {
-	return x % y;
-}
 
 jit_value_t VariableValue::compile_jit(Compiler&, jit_function_t& F, Type req_type) const {
 
 //	cout << "compile vv " << name->content << " : " << type << endl;
 //	cout << "req type : " << req_type << endl;
-
-	if (name->content == "+") {
-		if (req_type.getArgumentType(0).nature == Nature::POINTER and req_type.getArgumentType(1).nature == Nature::POINTER) {
-			return JIT_CREATE_CONST_POINTER(F, new LSFunction((void*) &jit_add));
-		} else {
-			return JIT_CREATE_CONST_POINTER(F,  new LSFunction((void*) &plus_function_int));
-		}
-	}
-	if (name->content == "-") {
-		if (req_type.getArgumentType(0).nature == Nature::POINTER and req_type.getArgumentType(1).nature == Nature::POINTER) {
-			return JIT_CREATE_CONST_POINTER(F, new LSFunction((void*) &jit_sub));
-		} else {
-			return JIT_CREATE_CONST_POINTER(F,  new LSFunction((void*) &minus_function_int));
-		}
-	}
-	if (name->content == "*") {
-		if (req_type.getArgumentType(0).nature == Nature::POINTER and req_type.getArgumentType(1).nature == Nature::POINTER) {
-			return JIT_CREATE_CONST_POINTER(F, new LSFunction((void*) &jit_mul));
-		} else {
-			return JIT_CREATE_CONST_POINTER(F,  new LSFunction((void*) &mul_function_int));
-		}
-	}
-	if (name->content == "/") {
-		if (req_type.getArgumentType(0).nature == Nature::POINTER and req_type.getArgumentType(1).nature == Nature::POINTER) {
-			return JIT_CREATE_CONST_POINTER(F, new LSFunction((void*) &jit_div));
-		} else {
-			return JIT_CREATE_CONST_POINTER(F,  new LSFunction((void*) &div_function_int));
-		}
-	}
-	if (name->content == "^") {
-		if (req_type.getArgumentType(0).nature == Nature::POINTER and req_type.getArgumentType(1).nature == Nature::POINTER) {
-			return JIT_CREATE_CONST_POINTER(F, new LSFunction((void*) &jit_pow));
-		} else {
-			return JIT_CREATE_CONST_POINTER(F,  new LSFunction((void*) &pow_function_int));
-		}
-	}
-	if (name->content == "%") {
-		if (req_type.getArgumentType(0).nature == Nature::POINTER and req_type.getArgumentType(1).nature == Nature::POINTER) {
-			return JIT_CREATE_CONST_POINTER(F, new LSFunction((void*) &jit_mod));
-		} else {
-			return JIT_CREATE_CONST_POINTER(F,  new LSFunction((void*) &mod_function_int));
-		}
-	}
 
 
 	if (var->scope == VarScope::INTERNAL) {

--- a/parser/value/VariableValue.cpp
+++ b/parser/value/VariableValue.cpp
@@ -34,9 +34,13 @@ extern map<string, jit_value_t> internals;
 extern map<string, jit_value_t> globals;
 extern map<string, jit_value_t> locals;
 
-LSValue* plus_function(LSValue* x, LSValue* y) {
-	return y->operator + (x);
-}
+extern LSValue* jit_add(LSValue* x, LSValue* y);
+extern LSValue* jit_sub(LSValue* x, LSValue* y);
+extern LSValue* jit_mul(LSValue* x, LSValue* y);
+extern LSValue* jit_div(LSValue* x, LSValue* y);
+extern LSValue* jit_pow(LSValue* x, LSValue* y);
+extern LSValue* jit_mod(LSValue* x, LSValue* y);
+
 
 int plus_function_int(int x, int y) {
 	return x + y;
@@ -63,23 +67,48 @@ jit_value_t VariableValue::compile_jit(Compiler&, jit_function_t& F, Type req_ty
 //	cout << "req type : " << req_type << endl;
 
 	if (name->content == "+") {
-		return JIT_CREATE_CONST_POINTER(F, new LSFunction((void*) &plus_function_int));
+		if (req_type.getArgumentType(0).nature == Nature::POINTER and req_type.getArgumentType(1).nature == Nature::POINTER) {
+			return JIT_CREATE_CONST_POINTER(F, new LSFunction((void*) &jit_add));
+		} else {
+			return JIT_CREATE_CONST_POINTER(F,  new LSFunction((void*) &plus_function_int));
+		}
 	}
 	if (name->content == "-") {
-		return JIT_CREATE_CONST_POINTER(F, new LSFunction((void*) &minus_function_int));
+		if (req_type.getArgumentType(0).nature == Nature::POINTER and req_type.getArgumentType(1).nature == Nature::POINTER) {
+			return JIT_CREATE_CONST_POINTER(F, new LSFunction((void*) &jit_sub));
+		} else {
+			return JIT_CREATE_CONST_POINTER(F,  new LSFunction((void*) &minus_function_int));
+		}
 	}
 	if (name->content == "*") {
-		return JIT_CREATE_CONST_POINTER(F, new LSFunction((void*) &mul_function_int));
+		if (req_type.getArgumentType(0).nature == Nature::POINTER and req_type.getArgumentType(1).nature == Nature::POINTER) {
+			return JIT_CREATE_CONST_POINTER(F, new LSFunction((void*) &jit_mul));
+		} else {
+			return JIT_CREATE_CONST_POINTER(F,  new LSFunction((void*) &mul_function_int));
+		}
 	}
 	if (name->content == "/") {
-		return JIT_CREATE_CONST_POINTER(F, new LSFunction((void*) &div_function_int));
+		if (req_type.getArgumentType(0).nature == Nature::POINTER and req_type.getArgumentType(1).nature == Nature::POINTER) {
+			return JIT_CREATE_CONST_POINTER(F, new LSFunction((void*) &jit_div));
+		} else {
+			return JIT_CREATE_CONST_POINTER(F,  new LSFunction((void*) &div_function_int));
+		}
 	}
 	if (name->content == "^") {
-		return JIT_CREATE_CONST_POINTER(F, new LSFunction((void*) &pow_function_int));
+		if (req_type.getArgumentType(0).nature == Nature::POINTER and req_type.getArgumentType(1).nature == Nature::POINTER) {
+			return JIT_CREATE_CONST_POINTER(F, new LSFunction((void*) &jit_pow));
+		} else {
+			return JIT_CREATE_CONST_POINTER(F,  new LSFunction((void*) &pow_function_int));
+		}
 	}
 	if (name->content == "%") {
-		return JIT_CREATE_CONST_POINTER(F, new LSFunction((void*) &mod_function_int));
+		if (req_type.getArgumentType(0).nature == Nature::POINTER and req_type.getArgumentType(1).nature == Nature::POINTER) {
+			return JIT_CREATE_CONST_POINTER(F, new LSFunction((void*) &jit_mod));
+		} else {
+			return JIT_CREATE_CONST_POINTER(F,  new LSFunction((void*) &mod_function_int));
+		}
 	}
+
 
 	if (var->scope == VarScope::INTERNAL) {
 

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -315,8 +315,11 @@ void Test::tests() {
 	 */
 	header("Function operators");
 	test("+(1, 2)", "3");
+	test("+([1], 2)", "[1, 2]");
+	test("+('test', 2)", "'test2'");
 //	test("-(9, 2)", "7");
 	test("*(5, 8)", "40");
+	test("*('test', 2)", "'testtest'");
 	test("/(48, 12)", "4");
 	test("^(2, 11)", "2048");
 	test("%(48, 5)", "3");
@@ -406,6 +409,7 @@ void Test::tests() {
 	test("['yo', 3, 4, 5].first()", "'yo'");
 	test("Array.last([1, 2, 3, 10, true, 'yo', null])", "null");
 	test("['yo', 3, 4, 5].last()", "5");
+	test("['yo', 3, 4, 5].foldLeft(+, 'concat:')", "'concat:yo345'");
 	test("Array.foldLeft([1, 2, 3, 10, true, 'yo', null], (x, y -> x + y), 'concat:')", "'concat:12310trueyonull'");
 	test("Array.foldRight([1, 2, 3, 10, true, 'yo', null], (x, y -> x + y), 'concat:')", "16");
 //	test("Array.shuffle([1, 2, 3, 10, true, 'yo', null])", "test shuffle ?");

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -324,6 +324,7 @@ void Test::tests() {
 	test("^(2, 11)", "2048");
 	test("%(48, 5)", "3");
 	test("let p = + p(1, 2)", "3");
+	test("let p = + p('test', 2)", "'test2'");
 	//test("let p = -\n p(9, 2)", "7");
 	test("let p = * p(5, 8)", "40");
 	test("let p = / p(48, 12)", "4");
@@ -381,8 +382,8 @@ void Test::tests() {
 	test("String.split('salut', '')", "['s', 'a', 'l', 'u', 't']");
 	test("String.startsWith('salut ça va', 'salut')", "true");
 	test("String.toArray('salut')", "['s', 'a', 'l', 'u', 't']");
-	test("Array.average([1, 2, 3, 4, 5, 6])", "3.5");
-	test("Array.average([])", "0");
+	test("String.charAt('salut', 1)", "'a'");
+	test("'salut'.substring(3, 4)", "'ut'");
 
 	header("Array standard library");
 	test("Array", "<class Array>");
@@ -391,6 +392,8 @@ void Test::tests() {
 	test("new Array()", "[]");
 	test("Array.size([1, 'yo', true])", "3");
 	test("[1, 'yo', true].size()", "3");
+	test("Array.average([1, 2, 3, 4, 5, 6])", "3.5");
+	test("Array.average([])", "0");
 	test("Array.map([1, 2, 3], x -> x ^ 2)", "[1, 4, 9]");
 	test("[3, 4, 5].map(x -> x ^ 2)", "[9, 16, 25]");
 	test("Array.map2([1, 'yo ', []], [12, 55, 9], (x, y -> x + y))", "[13, 'yo 55', [9]]");

--- a/vm/standard/ArraySTD.cpp
+++ b/vm/standard/ArraySTD.cpp
@@ -38,17 +38,26 @@ ArraySTD::ArraySTD() : Module("Array") {
 	method("filter", Type::ARRAY, {Type::ARRAY, filter_fun_type},(void*)&array_filter);
 	method("contains",Type::BOOLEAN_P, {Type::ARRAY, Type::POINTER}, (void*)&array_contains);
 	method("isEmpty",Type::BOOLEAN_P, {Type::ARRAY}, (void*)&array_isEmpty);
-	method("partition",Type::ARRAY, {Type::ARRAY, map_fun_type}, (void*)&array_partition);
+
+	Type partition_fun_type = Type::FUNCTION_P;
+	partition_fun_type.setArgumentType(0, Type::POINTER);
+	partition_fun_type.setReturnType(Type::POINTER);
+	method("partition",Type::ARRAY, {Type::ARRAY, partition_fun_type}, (void*)&array_partition);
 	method("first", Type::POINTER, {Type::ARRAY}, (void*)&array_first);
 	method("last", Type::POINTER, {Type::ARRAY}, (void*)&array_last);
-	method("foldLeft", Type::POINTER, {Type::ARRAY, map2_fun_type, Type::POINTER}, (void*)&array_foldLeft);
-	method("foldRight", Type::POINTER, {Type::ARRAY, map2_fun_type, Type::POINTER}, (void*)&array_foldRight);
+
+	Type fold_fun_type = Type::FUNCTION_P;
+	fold_fun_type.setArgumentType(0, Type::POINTER);
+	fold_fun_type.setArgumentType(1, Type::POINTER);
+	fold_fun_type.setReturnType(Type::POINTER);
+	method("foldLeft", Type::POINTER, {Type::ARRAY, fold_fun_type, Type::POINTER}, (void*)&array_foldLeft);
+	method("foldRight", Type::POINTER, {Type::ARRAY, fold_fun_type, Type::POINTER}, (void*)&array_foldRight);
 	method("reverse", Type::ARRAY, {Type::ARRAY}, (void*)&array_reverse);
 	method("shuffle", Type::ARRAY, {Type::ARRAY}, (void*)&array_shuffle);
 	method("search", Type::POINTER, {Type::ARRAY, Type::POINTER, Type::POINTER}, (void*)&array_search);
 	method("subArray", Type::ARRAY, {Type::ARRAY, Type::POINTER, Type::POINTER}, (void*)&array_subArray);
 	method("pop", Type::POINTER, {Type::ARRAY}, (void*)&array_pop);
-	method("push", Type::ARRAY, {Type::ARRAY}, (void*)&array_push);
+	method("push", Type::ARRAY, {Type::ARRAY, Type::POINTER}, (void*)&array_push);
 	method("pushAll", Type::ARRAY, {Type::ARRAY, Type::ARRAY}, (void*)&array_pushAll);
 	method("concat", Type::ARRAY, {Type::ARRAY, Type::ARRAY}, (void*)&array_concat);
 	method("join", Type::STRING, {Type::ARRAY, Type::STRING}, (void*)&array_join);

--- a/vm/standard/StringSTD.cpp
+++ b/vm/standard/StringSTD.cpp
@@ -7,14 +7,14 @@ using namespace std;
 
 StringSTD::StringSTD() : Module("String") {
 
-	method("charAt", Type::INTEGER_P, {Type::STRING}, (void*) &string_size);
-	method("contains", Type::BOOLEAN_P, {Type::STRING}, (void*) &string_contains);
+	method("charAt", Type::STRING, {Type::STRING, Type::INTEGER_P}, (void*) &string_charAt);
+	method("contains", Type::BOOLEAN_P, {Type::STRING, Type::STRING}, (void*) &string_contains);
 	method("endsWith", Type::BOOLEAN_P, {Type::STRING, Type::STRING}, (void*) &string_endsWith);
 	method("length", Type::INTEGER_P, {Type::STRING}, (void*) &string_length);
 	method("size", Type::INTEGER_P, {Type::STRING}, (void*) &string_size);
 	method("replace", Type::STRING, {Type::STRING, Type::STRING, Type::STRING}, (void*) &string_replace);
 	method("reverse", Type::STRING, {Type::STRING}, (void*) &string_reverse);
-	method("replace", Type::STRING, {Type::STRING, Type::INTEGER_P, Type::INTEGER_P}, (void*) &string_substring);
+	method("substring", Type::STRING, {Type::STRING, Type::INTEGER_P, Type::INTEGER_P}, (void*) &string_substring);
 	method("toArray", Type::ARRAY, {Type::STRING}, (void*) &string_toArray);
 	method("toLower", Type::STRING, {Type::STRING}, (void*) &string_toLower);
 	method("toUpper", Type::STRING, {Type::STRING}, (void*) &string_toUpper);


### PR DESCRIPTION
Overloaded functions operators (+, ...) to take pointers
- `+([1], 2) ==> [1, 2]`
- `[1, 2, 3].foldLeft(+,1) ==> 7`
- `*('a', 2) ==> 'aa'`

Corrected an issue in function calls on objects where the wrong `argumentType` was used to compile an argument because of the offset from `this`.

Removed code to avoid the use of `jit_insn_pow`, `jit_insn_round` and `jit_insn_cos` because the fix was not correct and the problem only occurs on my architecture.

Found issue on type of the value created when declaring a new variable
