### PR TITLE
Solve ()

### DIFF
--- a/src/compiler/syntaxic/SyntaxicAnalyser.cpp
+++ b/src/compiler/syntaxic/SyntaxicAnalyser.cpp
@@ -298,14 +298,20 @@ VariableDeclaration* SyntaxicAnalyser::eatVariableDeclaration() {
 
 Value* SyntaxicAnalyser::eatSimpleExpression() {
 
-	Value* e = new Expression();
+	Value* e = nullptr;
 
 	if (t->type == TokenType::OPEN_PARENTHESIS) {
 
 		eat();
-		e = eatExpression();
-		e->parenthesis = true;
-		eat(TokenType::CLOSING_PARENTHESIS);
+
+		if (t->type == TokenType::CLOSING_PARENTHESIS) {
+			eat();
+			e = new Nulll();
+		} else {
+			e = eatExpression();
+			e->parenthesis = true;
+			eat(TokenType::CLOSING_PARENTHESIS);
+		}
 
 	} else if (t->type == TokenType::PIPE) {
 
@@ -334,14 +340,14 @@ Value* SyntaxicAnalyser::eatSimpleExpression() {
 				ex->operatorr = new Operator(op);
 				ex->expression = eatSimpleExpression();
 
-				((Expression*) e)->v1 = ex;
+				e = new Expression(ex);
 			}
 
 		} else {
-
 			e = eatValue();
 		}
 	}
+
 
 	while (t->type == TokenType::OPEN_BRACKET || t->type == TokenType::OPEN_PARENTHESIS
 			|| t->type == TokenType::DOT) {

--- a/src/compiler/value/Expression.cpp
+++ b/src/compiler/value/Expression.cpp
@@ -15,14 +15,9 @@ namespace ls {
 
 Expression::Expression() : Expression(nullptr) {}
 
-Expression::Expression(Value* v) {
-	v1 = v;
-	v2 = nullptr;
-	op = nullptr;
-	ignorev2 = false;
-	no_op = false;
-	operations = 0;
-}
+Expression::Expression(Value* v) :
+	v1(v), v2(nullptr), op(nullptr), ignorev2(false), no_op(false), operations(0)
+{}
 
 Expression::~Expression() {
 	if (v1 != nullptr) {

--- a/test/general.cpp
+++ b/test/general.cpp
@@ -16,6 +16,7 @@ void Test::test_general() {
 	header("General");
 	success("", "null");
 	success("null", "null");
+	success("()", "null");
 	success("12", "12");
 	success("true", "true");
 	success("false", "false");


### PR DESCRIPTION
J'ai mis `e = nullptr` pour éviter une fuite mémoire inutile. Du coup j'ai `|'♫👽'|`qui ne retourne plus `2` mais je ne comprends vraiment pas pourquoi... 
