### PR TITLE
unique & sort

### DIFF
--- a/src/vm/standard/ArraySTD.cpp
+++ b/src/vm/standard/ArraySTD.cpp
@@ -63,6 +63,18 @@ ArraySTD::ArraySTD() : Module("Array") {
 			   {Type::INT_ARRAY, int_array_array, {Type::INTEGER}, (void*) &LSArray<int>::chunk},
 		   });
 
+	method("unique", {
+			   {Type::ARRAY, Type::VOID, {}, (void*) &LSArray<LSValue*>::unique},
+			   {Type::FLOAT_ARRAY, Type::VOID, {}, (void*) &LSArray<double>::unique},
+			   {Type::INT_ARRAY, Type::VOID, {}, (void*) &LSArray<int>::unique},
+		   });
+
+	method("sort", {
+			   {Type::ARRAY, Type::VOID, {}, (void*) &LSArray<LSValue*>::sort},
+			   {Type::FLOAT_ARRAY, Type::VOID, {}, (void*) &LSArray<double>::sort},
+			   {Type::INT_ARRAY, Type::VOID, {}, (void*) &LSArray<int>::sort},
+		   });
+
 	Type map2_fun_type = Type::FUNCTION;
 	map2_fun_type.setArgumentType(0, Type::POINTER);
 	map2_fun_type.setArgumentType(1, Type::POINTER);

--- a/src/vm/value/LSArray.hpp
+++ b/src/vm/value/LSArray.hpp
@@ -52,6 +52,8 @@ public:
 	LSArray<LSValue*>* map(const void*) const;
 	LSArray<LSArray<T>*>* chunk(int size = 1) const;
 	LSArray<LSArray<T>*>* chunk_1() const;
+	void unique();
+	void sort();
 	void iter(const LSFunction*) const;
 	int contains(const LSValue*) const;
 	int contains_int(int) const;

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -103,6 +103,12 @@ void Test::test_arrays() {
 	success("let x = [1,2,3,4]; x.chunk(3)", "[[1, 2, 3], [4]]");
 	success("let x = [1,2,3,4]; x.chunk()", "[[1], [2], [3], [4]]");
 
+	success("let x = [1,1,2,2,1]; x.unique(); x", "[1, 2, 1]");
+	success("let x = ['a','a','b']; x.unique(); x", "['a', 'b']");
+
+	success("let x = [3,1,2]; x.sort(); x", "[1, 2, 3]");
+	success("let x = [[[]],[[],[],[]],[[],[]]]; x.sort(); x", "[[[]], [[], []], [[], [], []]]");
+
 	success("Array.filter([1, 2, 3, 10, true, 'yo'], x -> x > 2)", "[3, 10, 'yo']");
 	success("[3, 4, 5].filter(x -> x > 6)", "[]");
 


### PR DESCRIPTION
J'ai osé modifier l'implémentation de l’opérateur `bool LSArray<T>::operator < (const LSValue* v) const`.

Egalement j'ai préféré implémenté `unique` et `sort` de façon inline pour ne pas faire des copies mémoire inutiles.

Egalement j'ai implémenté `unique` à l'aide de la librairie standard c++. Il n'a pas le comportement que tu as suggéré ! `unique([1,1,2,1]) = [1,2,1] != [1,2]` pour obtenir `[1,2]` il faut faire un `sort` au préalable.

```
let x = [3,1,1,2,2,1,1];
x.sort();
x.unique();
x; // [1,2,3]
```

J'ai un souci avec `unique` car il doit supprimer des éléments mais quand j'utilise `LSValue::delete_val` j'ai un segmentation fault (je l'ai laissé en commentaire pour que tu voies de quoi je parles).
