### PR TITLE
array : lexicographical order

### DIFF
--- a/src/vm/standard/ArraySTD.cpp
+++ b/src/vm/standard/ArraySTD.cpp
@@ -58,9 +58,9 @@ ArraySTD::ArraySTD() : Module("Array") {
 	float_array_array.setElementType(Type::FLOAT_ARRAY);
 
 	method("chunk", {
-		{Type::ARRAY, array_array, {}, (void*) &LSArray<LSValue*>::chunk_1},
-		{Type::FLOAT_ARRAY, float_array_array, {}, (void*) &LSArray<double>::chunk_1},
-		{Type::INT_ARRAY, int_array_array, {}, (void*) &LSArray<int>::chunk_1},
+		{Type::ARRAY, array_array, {}, (void*) array_chunk_1_ptr},
+		{Type::FLOAT_ARRAY, float_array_array, {}, (void*) array_chunk_1_float},
+		{Type::INT_ARRAY, int_array_array, {}, (void*) array_chunk_1_int},
 
 		{Type::ARRAY, array_array, {Type::INTEGER}, (void*) &LSArray<LSValue*>::chunk},
 		{Type::FLOAT_ARRAY, float_array_array, {Type::INTEGER}, (void*) &LSArray<double>::chunk},
@@ -127,7 +127,7 @@ ArraySTD::ArraySTD() : Module("Array") {
 
 	method("partition", {
 		{Type::ARRAY, Type::ARRAY, {partition_fun_type}, (void*) &LSArray<LSValue*>::partition},
-		{Type::ARRAY, Type::INT_ARRAY, {partition_fun_type_int}, (void*) &LSArray<int>::partition}
+		{Type::ARRAY, Type::ARRAY, {partition_fun_type_int}, (void*) &LSArray<int>::partition}
 	});
 
 	method("first", Type::ARRAY, Type::POINTER, {}, (void*) &array_first);
@@ -520,6 +520,18 @@ LSValue* array_sum(const LSArray<LSValue*>*) {
 LSValue* array_unshift(const LSArray<LSValue*>*, const LSValue*) {
 	// TODO
 	return new LSArray<LSValue*>();
+}
+
+LSArray<LSValue*>* array_chunk_1_ptr(const LSArray<LSValue*>* array) {
+	return array->chunk(1);
+}
+
+LSArray<LSValue*>* array_chunk_1_int(const LSArray<int>* array) {
+	return array->chunk(1);
+}
+
+LSArray<LSValue*>* array_chunk_1_float(const LSArray<double>* array) {
+	return array->chunk(1);
 }
 
 }

--- a/src/vm/standard/ArraySTD.hpp
+++ b/src/vm/standard/ArraySTD.hpp
@@ -39,6 +39,9 @@ LSValue* array_shift(const LSArray<LSValue*>* array);
 LSArray<LSValue*>* array_sort(const LSArray<LSValue*>* array, const LSNumber* order);
 LSValue* array_sum(const LSArray<LSValue*>* array);
 LSValue* array_unshift(const LSArray<LSValue*>* array, const LSValue* value);
+LSArray<LSValue*>* array_chunk_1_ptr(const LSArray<LSValue*>* array);
+LSArray<LSValue*>* array_chunk_1_int(const LSArray<int>* array);
+LSArray<LSValue*>* array_chunk_1_float(const LSArray<double>* array);
 
 }
 

--- a/src/vm/standard/StringSTD.cpp
+++ b/src/vm/standard/StringSTD.cpp
@@ -133,7 +133,7 @@ LSValue* string_size(LSString* string) {
 }
 
 LSValue* string_split(LSString* string, LSString* delimiter) {
-	LSArray<LSString*>* parts = new LSArray<LSString*>();
+	LSArray<LSValue*>* parts = new LSArray<LSValue*>();
 	if (*delimiter == "") {
 		for (char c : *string) {
 			parts->push_no_clone(new LSString(c));

--- a/src/vm/value/LSArray.hpp
+++ b/src/vm/value/LSArray.hpp
@@ -48,8 +48,7 @@ public:
 	LSArray<LSValue*>* map(const void*) const;
 	LSArray<int>* map_int(const void*) const;
 	LSArray<double>* map_real(const void*) const;
-	LSArray<LSArray<T>*>* chunk(int size = 1) const;
-	LSArray<LSArray<T>*>* chunk_1() const;
+	LSArray<LSValue*>* chunk(int size = 1) const;
 	LSArray<T>* unique();
 	LSArray<T>* sort();
 	void iter(const LSFunction*) const;
@@ -63,7 +62,7 @@ public:
 	LSValue* foldLeft(const void* fun, const LSValue* initial) const;
 	LSValue* foldRight(const void* fun, const LSValue* initial) const;
 	LSArray<T>* insert_v(const T v, const LSValue* pos);
-	LSArray<LSArray<T>*>* partition(const void* fun) const;
+	LSArray<LSValue*>* partition(const void* fun) const;
 	LSArray<LSValue*>* map2(const LSArray<LSValue*>*, const void* fun) const;
 	LSArray<LSValue*>* map2_int(const LSArray<int>*, const void* fun) const;
 	int search(const LSValue* search, const int start) const;

--- a/src/vm/value/LSObject.cpp
+++ b/src/vm/value/LSObject.cpp
@@ -49,8 +49,8 @@ void LSObject::addField(string name, LSValue* var) {
 	var->refs++;
 }
 
-LSArray<LSString*>* LSObject::get_keys() const {
-	LSArray<LSString*>* keys = new LSArray<LSString*>();
+LSArray<LSValue*>* LSObject::get_keys() const {
+	LSArray<LSValue*>* keys = new LSArray<LSValue*>();
 	for (auto i = values.begin(); i != values.end(); i++) {
 		keys->push_no_clone(new LSString(i->first));
 	}

--- a/src/vm/value/LSObject.hpp
+++ b/src/vm/value/LSObject.hpp
@@ -26,7 +26,7 @@ public:
 	virtual ~LSObject();
 
 	void addField(std::string name, LSValue* value);
-	LSArray<LSString*>* get_keys() const;
+	LSArray<LSValue*>* get_keys() const;
 	LSArray<LSValue*>* get_values() const;
 
 	/*

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -31,6 +31,16 @@ void Test::test_arrays() {
 	success("[1 2 3]", "[1, 2, 3]");
 	success("['yo' 'ya' 'yu']", "['yo', 'ya', 'yu']");
 	success("[true false true true]", "[true, false, true, true]");
+	success("[1,2,3,4] < [1,2,3,5]", "true");
+	success("[1,2,4,4] < [1,2,3,5]", "false");
+	success("[1,2,3,4.1] < [1,2,3,5.1]", "true");
+	success("[1,2,4,4.1] < [1,2,3,5.1]", "false");
+	success("['1','2','3','4'] < ['1','2','3','5']", "true");
+	success("['1','2','4','4'] < ['1','2','3','5']", "false");
+	success("[1,2,3,4] < [1,2,3,5.1]", "true");
+	success("[1,2,4,4.1] < [1,2,3,5]", "false");
+	success("[1,2,'3'] < [1,2,3]", "false");
+	success("[1,1,'3'] < [1,2,3]", "true");
 
 
 	/*
@@ -116,6 +126,7 @@ void Test::test_arrays() {
 	success("let x = [3, 1, 2] x.sort() x", "[1, 2, 3]");
 	success("let x = ['foo', 'yop', 'abc'] x.sort() x", "['abc', 'foo', 'yop']");
 	success("let x = [[[]], [[], [], []], [[], []]]; x.sort() x", "[[[]], [[], []], [[], [], []]]");
+	success("let x = [[1, 2, 3], [3, 1, 2], [2, 3, 1]]; x.sort() x", "[[1, 2, 3], [2, 3, 1], [3, 1, 2]]");
 
 	success("Array.filter([1, 2, 3, 10, true, 'yo'], x -> x > 2)", "[3, 10, 'yo']");
 	success("[3, 4, 5].filter(x -> x > 6)", "[]");


### PR DESCRIPTION
Si possible il ne faut plus créer de `LSArray<LSString*>` ou autre mais uniquement :  `LSArray<LSValue*>, LSArray<int>, LSArray<double>`

Je pense qu'au lieu de faire

```
template <typename T>
inline out_type LSArray<T>::method() {
    (LSValue*) (*this)[0] // ...
}
```

il faudrait mieux faire

```
template <>
inline out_type LSArray<LSValue*>::method() {
    (*this)[0] // ...
}
```
