### PR TITLE
match optimization

### DIFF
--- a/src/compiler/value/Match.hpp
+++ b/src/compiler/value/Match.hpp
@@ -19,6 +19,8 @@ public:
 		Pattern(Value* begin, Value* end);
 		~Pattern();
 
+		inline bool is_default() const { return !begin && !end; }
+
 		void print(std::ostream&, int indent, bool debug) const;
 		jit_value_t match(Compiler &c, jit_value_t v) const;
 	};


### PR DESCRIPTION
Permet au match d'avoir différents type de retour à condition d'avoir un pattern default.

```
match x {
    'test' : 11
    .. : 0
} // type == INTEGER

match x {
    'test' : 11
    'autre' : 0
} // type == POINTER
```
