### PR TITLE
Fix map method

### DIFF
--- a/src/compiler/Compiler.cpp
+++ b/src/compiler/Compiler.cpp
@@ -52,12 +52,11 @@ void Compiler::add_var(std::string& name, jit_value_t& value, const Type& type, 
 }
 
 CompilerVar& Compiler::get_var(const std::string& name) {
-	int i = variables.size() - 1;
-	while (i >= 0) {
-		try {
-			return variables[i].at(name);
-		} catch (std::exception& e) {}
-		i--;
+	for (int i = variables.size() - 1; i >= 0; --i) {
+		auto it = variables[i].find(name);
+		if (it != variables[i].end()) {
+			return it->second;
+		}
 	}
 	return *((CompilerVar*) nullptr); // Should not reach this line
 }

--- a/src/compiler/Compiler.hpp
+++ b/src/compiler/Compiler.hpp
@@ -15,9 +15,9 @@ public:
 	jit_value_t value;
 	Type type;
 	bool reference;
-	CompilerVar() : value(jit_value_t{}), type(Type::UNKNOWN), reference(false) {};
+	CompilerVar() : value(jit_value_t{}), type(Type::UNKNOWN), reference(false) {}
 	CompilerVar(jit_value_t& value, const Type& type, bool reference) :
-		value(value), type(type), reference(reference) {};
+		value(value), type(type), reference(reference) {}
 };
 
 class Compiler {

--- a/src/compiler/instruction/Break.cpp
+++ b/src/compiler/instruction/Break.cpp
@@ -10,7 +10,6 @@ namespace ls {
 
 Break::Break() {
 	value = 1;
-	can_return = false;
 }
 
 Break::~Break() {}

--- a/src/compiler/instruction/ClassDeclaration.cpp
+++ b/src/compiler/instruction/ClassDeclaration.cpp
@@ -7,9 +7,7 @@ using namespace std;
 
 namespace ls {
 
-ClassDeclaration::ClassDeclaration() {
-	can_return = false;
-}
+ClassDeclaration::ClassDeclaration() {}
 
 ClassDeclaration::~ClassDeclaration() {}
 

--- a/src/compiler/instruction/Continue.cpp
+++ b/src/compiler/instruction/Continue.cpp
@@ -8,7 +8,6 @@ namespace ls {
 
 Continue::Continue() {
 	value = 1;
-	can_return = false;
 }
 
 Continue::~Continue() {}

--- a/src/compiler/instruction/Foreach.cpp
+++ b/src/compiler/instruction/Foreach.cpp
@@ -1,5 +1,5 @@
 /*
- * for (let k : let v in array) { ... }
+ * for (let k : let v in array) { ... }
  */
 #include "../../compiler/instruction/Foreach.hpp"
 
@@ -51,7 +51,9 @@ void Foreach::analyse(SemanticAnalyser* analyser, const Type&) {
 	var_type = array->type.getElementType();
 
 	if (key != nullptr) {
-		key_var = analyser->add_var(key, Type::POINTER, nullptr, nullptr);
+		key_type = array->type.getElementType(1);
+		if (key_type == Type::UNKNOWN) key_type = Type::INTEGER; // If no key type in array key = 0, 1, 2...
+		key_var = analyser->add_var(key, key_type, nullptr, nullptr);
 	}
 
 	value_var = analyser->add_var(value, var_type, nullptr, nullptr);
@@ -104,7 +106,7 @@ jit_value_t Foreach::compile(Compiler& c) const {
 	c.enter_loop(&label_end, &label_cond);
 
 	// Array
-	jit_value_t a = array->compile(c);
+	jit_value_t a = array->compile(c); // break continue into array ?
 
 	// Variable it = begin()
 	jit_value_t it = jit_value_create(c.F, JIT_POINTER);

--- a/src/compiler/instruction/Foreach.hpp
+++ b/src/compiler/instruction/Foreach.hpp
@@ -18,6 +18,7 @@ public:
 	Token* value;
 	Value* array;
 	Block* body;
+	Type key_type;
 	Type var_type;
 	SemanticVar* value_var;
 	SemanticVar* key_var;

--- a/src/compiler/instruction/Return.cpp
+++ b/src/compiler/instruction/Return.cpp
@@ -36,7 +36,6 @@ void Return::analyse(SemanticAnalyser* analyser, const Type& req_type) {
 //		f->can_return(expression->type);
 	}
 	type = expression->type;
-	can_return = true;
 }
 
 jit_value_t Return::compile(Compiler& c) const {

--- a/src/compiler/instruction/VariableDeclaration.cpp
+++ b/src/compiler/instruction/VariableDeclaration.cpp
@@ -45,10 +45,10 @@ void VariableDeclaration::print(ostream& os, int indent, bool debug) const {
 
 void VariableDeclaration::analyse(SemanticAnalyser* analyser, const Type&) {
 
+	vars.clear();
 	for (unsigned i = 0; i < variables.size(); ++i) {
 
 		Token* var = variables[i];
-		Type type = Type::UNKNOWN;
 		Value* value = nullptr;
 
 		SemanticVar* v = analyser->add_var(var, Type::UNKNOWN, value, this);
@@ -64,7 +64,6 @@ void VariableDeclaration::analyse(SemanticAnalyser* analyser, const Type&) {
 		}
 
 		vars.insert(pair<string, SemanticVar*>(var->content, v));
-		vars.at(var->content)->type = v->type;
 	}
 }
 
@@ -72,27 +71,25 @@ jit_value_t VariableDeclaration::compile(Compiler& c) const {
 
 	for (unsigned i = 0; i < variables.size(); ++i) {
 
-		std::string name = variables.at(i)->content;
+		std::string name = variables[i]->content;
 		SemanticVar* v = vars.at(name);
 
 		if (i < expressions.size()) {
 
 			Value* ex = expressions[i];
 
-			jit_value_t var = jit_value_create(c.F, VM::get_jit_type(v->type));
-			c.add_var(name, var, v->type, false);
-
-			jit_value_t val;
 			if (Reference* ref = dynamic_cast<Reference*>(ex)) {
-				val = c.get_var(ref->variable->content).value;
+				jit_value_t val = c.get_var(ref->variable->content).value;
 				c.add_var(name, val, v->type, true);
 			} else {
+				jit_value_t var = jit_value_create(c.F, VM::get_jit_type(v->type));
+				jit_value_t val = ex->compile(c);
 
-				val = ex->compile(c);
-				if (expressions.at(i)->type.must_manage_memory()) {
+				if (ex->type.must_manage_memory()) {
 					VM::inc_refs(c.F, val);
 				}
-				c.set_var_type(name, ex->type);
+
+				c.add_var(name, var, ex->type, false);
 				jit_insn_store(c.F, var, val);
 			}
 		} else {
@@ -102,7 +99,6 @@ jit_value_t VariableDeclaration::compile(Compiler& c) const {
 
 			jit_value_t val = VM::create_null(c.F);
 			jit_insn_store(c.F, var, val);
-//			VM::inc_refs(c.F, val);
 		}
 	}
 	return nullptr;

--- a/src/compiler/semantic/SemanticAnalyser.cpp
+++ b/src/compiler/semantic/SemanticAnalyser.cpp
@@ -133,12 +133,10 @@ void SemanticAnalyser::leave_function() {
 }
 
 void SemanticAnalyser::enter_block() {
-	in_block = true;
 	variables.back().push_back(map<std::string, SemanticVar*> {});
 }
 
 void SemanticAnalyser::leave_block() {
-	in_block = false;
 	variables.back().pop_back();
 }
 

--- a/src/compiler/semantic/SemanticAnalyser.hpp
+++ b/src/compiler/semantic/SemanticAnalyser.hpp
@@ -48,7 +48,6 @@ class SemanticAnalyser {
 public:
 
 	Program* program;
-	bool in_block = false;
 	bool in_program = false;
 
 	std::map<std::string, SemanticVar*> internal_vars;

--- a/src/compiler/value/Block.cpp
+++ b/src/compiler/value/Block.cpp
@@ -47,8 +47,7 @@ void Block::analyse(SemanticAnalyser* analyser, const Type& req_type) {
 
 		can_return = can_return or instructions[i]->can_return;
 
-		bool can_return = instructions[i]->can_return or (i == instructions.size() - 1);
-		if (can_return) {
+		if (instructions[i]->can_return or (i == instructions.size() - 1)) {
 			type = Type::get_compatible_type(type, instructions[i]->type);
 		}
 	}

--- a/src/compiler/value/Function.hpp
+++ b/src/compiler/value/Function.hpp
@@ -30,7 +30,6 @@ public:
 	virtual ~Function();
 
 	void addArgument(Token* token, bool reference, Value* defaultValue);
-	void can_return(Type type);
 	void capture(SemanticVar* var);
 
 	virtual void print(std::ostream&, int indent, bool debug) const override;

--- a/src/compiler/value/If.cpp
+++ b/src/compiler/value/If.cpp
@@ -47,7 +47,7 @@ void If::analyse(SemanticAnalyser* analyser, const Type& req_type) {
 	condition->analyse(analyser, Type::BOOLEAN);
 	then->analyse(analyser, req_type);
 
-	can_return = can_return or then->can_return;
+	can_return = then->can_return;
 
 	if (elze != nullptr) {
 

--- a/src/compiler/value/Map.cpp
+++ b/src/compiler/value/Map.cpp
@@ -24,7 +24,7 @@ Map::~Map()
 void Map::print(std::ostream& os, int indent, bool debug) const {
 	os << "[\n";
 	for (size_t i = 0; i < values.size(); ++i) {
-		os << tabs(indent);
+		os << tabs(indent+1);
 		keys[i]->print(os, indent + 1, debug);
 		os << " : ";
 		values[i]->print(os, indent + 1, debug);

--- a/src/compiler/value/Match.cpp
+++ b/src/compiler/value/Match.cpp
@@ -98,9 +98,6 @@ void Match::analyse(ls::SemanticAnalyser* analyser, const Type&) {
 			ret->analyse(analyser, Type::UNKNOWN);
 			type = Type::get_compatible_type(type, ret->type);
 		}
-		if (type != Type::INTEGER || type != Type::LONG || type != Type::FLOAT) {
-			type = Type::POINTER;
-		}
 		for (Value* ret : returns) {
 			ret->analyse(analyser, type);
 		}
@@ -133,19 +130,9 @@ void Match::analyse(ls::SemanticAnalyser* analyser, const Type&) {
 
 jit_value_t Match::compile(Compiler& c) const {
 
-	jit_type_t return_type;
-	if (type == Type::INTEGER)
-		return_type = JIT_INTEGER;
-	else if (type == Type::LONG)
-		return_type = JIT_INTEGER_LONG;
-	else if (type == Type::FLOAT)
-		return_type = JIT_FLOAT;
-	else
-		return_type = JIT_POINTER;
-
 	jit_value_t v = value->compile(c);
 
-	jit_value_t res = jit_value_create(c.F, return_type);
+	jit_value_t res = jit_value_create(c.F, VM::get_jit_type(type));
 	jit_label_t label_end = jit_label_undefined;
 
 	for (size_t i = 0; i < pattern_list.size(); ++i) {

--- a/src/vm/Type.cpp
+++ b/src/vm/Type.cpp
@@ -288,10 +288,8 @@ bool Type::list_compatible(const std::vector<Type>& expected, const std::vector<
 
 	if (expected.size() != actual.size()) return false;
 
-	for (unsigned a = 0; a < expected.size(); ++a) {
-
-		if (not expected.at(a).compatible(actual.at(a))) return false;
-//		cout << "YES" << endl;
+	for (unsigned i = 0; i < expected.size(); ++i) {
+		if (not expected[i].compatible(actual[i])) return false;
 	}
 	return true;
 }
@@ -311,6 +309,18 @@ bool Type::more_specific(const Type& neww, const Type& old) {
 //		cout << "old element type : " << old.getElementType() << endl;
 
 		if (Type::more_specific(neww.getElementType(), old.getElementType())) {
+//			cout << "YES" << endl;
+			return true;
+		}
+	}
+
+	if (neww.raw_type == RawType::MAP and old.raw_type == RawType::MAP) {
+
+//		cout << "new element type : " << neww.getElementType() << endl;
+//		cout << "old element type : " << old.getElementType() << endl;
+
+		if (Type::more_specific(neww.getElementType(0), old.getElementType(0))
+				|| Type::more_specific(neww.getElementType(1), old.getElementType(1))) {
 //			cout << "YES" << endl;
 			return true;
 		}
@@ -414,6 +424,9 @@ ostream& operator << (ostream& os, const Type& type) {
 	}
 	if (type.raw_type == RawType::ARRAY) {
 		os << " of " << type.getElementType();
+	}
+	if (type.raw_type == RawType::MAP) {
+		os << " of " << type.getElementType(0) << " → " << type.getElementType(1);
 	}
 	os << "}";
 	return os;

--- a/src/vm/Type.hpp
+++ b/src/vm/Type.hpp
@@ -21,7 +21,6 @@ public:
 	virtual const std::string getName() const { return "?"; }
 	virtual const std::string getClass() const { return "?"; }
 	virtual const std::string getJsonName() const { return "?"; }
-	virtual bool operator == (const BaseRawType*) { return true; }
 	virtual bool derived_from(const BaseRawType*) const { return false; }
 };
 
@@ -29,8 +28,6 @@ class VoidRawType : public BaseRawType {
 public:
 	virtual const std::string getName() const { return "void"; }
 	virtual const std::string getJsonName() const { return "void"; }
-	virtual bool operator == (const BaseRawType*) { return false; }
-	virtual bool operator == (const VoidRawType*) { return true; }
 	virtual bool derived_from(const BaseRawType*) const { return true; }
 };
 
@@ -39,8 +36,6 @@ public:
 	virtual const std::string getName() const { return "null"; }
 	virtual const std::string getClass() const { return "Null"; }
 	virtual const std::string getJsonName() const { return "null"; }
-	virtual bool operator == (const BaseRawType*) { return false; }
-	virtual bool operator == (const NullRawType*) { return true; }
 	virtual bool derived_from(const BaseRawType*) const { return true; }
 };
 
@@ -49,8 +44,6 @@ public:
 	virtual const std::string getName() const { return "bool"; }
 	virtual const std::string getClass() const { return "Boolean"; }
 	virtual const std::string getJsonName() const { return "boolean"; }
-	virtual bool operator == (const BaseRawType*) { return false; }
-	virtual bool operator == (const BooleanRawType*) { return true; }
 	virtual bool derived_from(const BaseRawType*) const { return true; }
 };
 
@@ -59,8 +52,6 @@ public:
 	virtual const std::string getName() const { return "number"; }
 	virtual const std::string getClass() const { return "Number"; }
 	virtual const std::string getJsonName() const { return "number"; }
-	virtual bool operator == (const BaseRawType*) { return false; }
-	virtual bool operator == (const NumberRawType*) { return true; }
 	virtual bool derived_from(const BaseRawType*) const { return true; }
 };
 
@@ -69,8 +60,6 @@ public:
 	virtual const std::string getName() const { return "int"; }
 	virtual const std::string getClass() const { return "Number"; }
 	virtual const std::string getJsonName() const { return "number"; }
-	virtual bool operator == (const BaseRawType*) { return false; }
-	virtual bool operator == (const IntegerRawType*) { return true; }
 	virtual bool operator > (const NumberRawType*) { return true; }
 	virtual bool derived_from(const NumberRawType*) const { return true; }
 };
@@ -80,8 +69,6 @@ public:
 	virtual const std::string getName() const { return "long"; }
 	virtual const std::string getClass() const { return "Number"; }
 	virtual const std::string getJsonName() const { return "number"; }
-	virtual bool operator == (const BaseRawType*) { return false; }
-	virtual bool operator == (const LongRawType*) { return true; }
 	virtual bool derived_from(const NumberRawType*) const { return true; }
 };
 
@@ -90,8 +77,6 @@ public:
 	virtual const std::string getName() const { return "real"; }
 	virtual const std::string getClass() const { return "Number"; }
 	virtual const std::string getJsonName() const { return "number"; }
-	virtual bool operator == (const BaseRawType*) { return false; }
-	virtual bool operator == (const FloatRawType*) { return true; }
 	virtual bool derived_from(const NumberRawType*) const { return true; }
 };
 
@@ -100,8 +85,6 @@ public:
 	virtual const std::string getName() const { return "string"; }
 	virtual const std::string getClass() const { return "String"; }
 	virtual const std::string getJsonName() const { return "string"; }
-	virtual bool operator == (const BaseRawType*) { return false; }
-	virtual bool operator == (const StringRawType*) { return true; }
 	virtual bool derived_from(const BaseRawType*) const { return true; }
 };
 
@@ -110,8 +93,6 @@ public:
 	virtual const std::string getName() const { return "array"; }
 	virtual const std::string getClass() const { return "Array"; }
 	virtual const std::string getJsonName() const { return "array"; }
-	virtual bool operator == (const BaseRawType*) { return false; }
-	virtual bool operator == (const ArrayRawType*) { return true; }
 	virtual bool derived_from(const BaseRawType*) const { return true; }
 };
 
@@ -120,8 +101,6 @@ public:
 	virtual const std::string getName() const { return "map"; }
 	virtual const std::string getClass() const { return "Map"; }
 	virtual const std::string getJsonName() const { return "map"; }
-	virtual bool operator == (const BaseRawType*) { return false; }
-	virtual bool operator == (const MapRawType*) { return true; }
 	virtual bool derived_from(const BaseRawType*) const { return true; }
 };
 
@@ -130,8 +109,6 @@ public:
 	virtual const std::string getName() const { return "interval"; }
 	virtual const std::string getClass() const { return "Array"; }
 	virtual const std::string getJsonName() const { return "array"; }
-	virtual bool operator == (const BaseRawType*) { return false; }
-	virtual bool operator == (const IntervalRawType*) { return true; }
 	virtual bool derived_from(const ArrayRawType*) const { return true; }
 };
 
@@ -140,8 +117,6 @@ public:
 	virtual const std::string getName() const { return "object"; }
 	virtual const std::string getClass() const { return "Object"; }
 	virtual const std::string getJsonName() const { return "object"; }
-	virtual bool operator == (const BaseRawType*) { return false; }
-	virtual bool operator == (const ObjectRawType*) { return true; }
 	virtual bool derived_from(const BaseRawType*) const { return true; }
 };
 
@@ -150,8 +125,6 @@ public:
 	virtual const std::string getName() const { return "function"; }
 	virtual const std::string getClass() const { return "Function"; }
 	virtual const std::string getJsonName() const { return "function"; }
-	virtual bool operator == (const BaseRawType*) { return false; }
-	virtual bool operator == (const FunctionRawType*) { return true; }
 	virtual bool derived_from(const BaseRawType*) const { return true; }
 };
 
@@ -160,8 +133,6 @@ public:
 	virtual const std::string getName() const { return "class"; }
 	virtual const std::string getClass() const { return "Class"; }
 	virtual const std::string getJsonName() const { return "class"; }
-	virtual bool operator == (const BaseRawType*) { return false; }
-	virtual bool operator == (const ClassRawType*) { return true; }
 	virtual bool derived_from(const BaseRawType*) const { return true; }
 };
 

--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -97,7 +97,7 @@ string VM::execute(const std::string code, std::string ctx, ExecMode mode) {
 	/*
 	 * Debug
 	 */
-//	cout << "Program: "; program->print(cout, true);
+	//cout << "Program: "; program->print(cout, true);
 
 	// Compilation
 	internals.clear();

--- a/src/vm/value/LSClass.cpp
+++ b/src/vm/value/LSClass.cpp
@@ -60,7 +60,7 @@ Method* LSClass::getMethod(std::string& name, Type obj_type, vector<Type>& args)
 	try {
 		vector<Method>& impl = methods.at(name);
 		Method* best = nullptr;
-		for (auto& m : impl) {
+		for (Method& m : impl) {
 //			cout << "Test impl : " << m.type << endl;
 
 			if (m.obj_type.compatible(obj_type) and Type::list_compatible(m.type.arguments_types, args)) {

--- a/test/map.cpp
+++ b/test/map.cpp
@@ -12,12 +12,13 @@ void Test::test_map() {
 
 	success("let x = [1 : 1] x.insert(2, 2)", "[1 : 1 2 : 2]");
 	success("let x = ['a' : 'a'] x.insert(2, 2)", "[2 : 2 'a' : 'a']");
-	success("let x = [1 : 'a'] x.insert(2, 2)", "[1 : 'a' 2 : 2]");
+	success("let x = [1 : 'a'] x.insert(2, 3)", "[1 : 'a' 2 : 3]");
+	success("let x = ['a' : 1] x.insert(2, 3)", "[2 : 3 'a' : 1]");
 
-	//success("let x = [1 : 1] x.clear()", "[]");
+	success("let x = [1 : 1] x.clear()", "[]");
 	success("let x = ['a' : 'a'] x.clear()", "[]");
 
-	//success("let x = [1 : 1] x.erase(1)", "[]");
+	success("let x = [1 : 1] x.erase(1)", "[]");
 	success("let x = ['a' : 'a'] x.erase('a')", "[]");
 	success("let x = ['a' : 'a'] x.erase('b')", "['a' : 'a']");
 	success("let x = ['a' : 1] x.erase(3.14)", "['a' : 1]");


### PR DESCRIPTION
J'ai corrigé le problème d'appel de méthodes que j'avais avec les map.

En lisant le code pour comprendre comment il fonctionnait j'ai pas pu m'empêcher de modifier des trucs (supprimé le code inutile, modifier les `at(i)` en `[i]` quand on est sûr que `i` est valide, ...)
