### PR TITLE
Semantic analyse of block and return

### DIFF
--- a/src/compiler/instruction/ExpressionInstruction.cpp
+++ b/src/compiler/instruction/ExpressionInstruction.cpp
@@ -25,7 +25,6 @@ void ExpressionInstruction::analyse(SemanticAnalyser* analyser, const Type& req_
 		value->analyse(analyser, req_type);
 		type = value->type;
 	}
-	can_return = value->can_return;
 }
 
 jit_value_t ExpressionInstruction::compile(Compiler& c) const {

--- a/src/compiler/instruction/ExpressionInstruction.cpp
+++ b/src/compiler/instruction/ExpressionInstruction.cpp
@@ -18,13 +18,26 @@ void ExpressionInstruction::print(ostream& os, int indent, bool debug) const {
 }
 
 void ExpressionInstruction::analyse(SemanticAnalyser* analyser, const Type& req_type) {
-	value->analyse(analyser, req_type);
-	type = value->type;
+	if (req_type.nature == Nature::VOID) {
+		value->analyse(analyser, Type::UNKNOWN);
+		type = Type::VOID;
+	} else {
+		value->analyse(analyser, req_type);
+		type = value->type;
+	}
 	can_return = value->can_return;
 }
 
 jit_value_t ExpressionInstruction::compile(Compiler& c) const {
-	return value->compile(c);
+	jit_value_t v = value->compile(c);
+	if (type.nature == Nature::VOID) {
+		if (value->type.must_manage_memory()) {
+			VM::delete_temporary(c.F, v);
+		}
+		return nullptr;
+	} else {
+		return v;
+	}
 }
 
 }

--- a/src/compiler/instruction/For.cpp
+++ b/src/compiler/instruction/For.cpp
@@ -63,7 +63,7 @@ void For::print(ostream& os, int indent, bool debug) const {
 void For::analyse(SemanticAnalyser* analyser, const Type&) {
 
 	for (unsigned i = 0; i < variablesValues.size(); ++i) {
-		variablesValues[i]->analyse(analyser);
+		variablesValues[i]->analyse(analyser, Type::UNKNOWN);
 	}
 	for (unsigned i = 0; i < variables.size(); ++i) {
 
@@ -86,7 +86,7 @@ void For::analyse(SemanticAnalyser* analyser, const Type&) {
 		}
 	}
 	if (condition != nullptr) {
-		condition->analyse(analyser);
+		condition->analyse(analyser, Type::UNKNOWN);
 	}
 	for (auto it : iterations) {
 		it->analyse(analyser, Type::VOID);

--- a/src/compiler/instruction/Foreach.cpp
+++ b/src/compiler/instruction/Foreach.cpp
@@ -40,7 +40,7 @@ void Foreach::print(ostream& os, int indent, bool debug) const {
 void Foreach::analyse(SemanticAnalyser* analyser, const Type&) {
 
 
-	container->analyse(analyser);
+	container->analyse(analyser, Type::UNKNOWN);
 
 	if (container->type.element_types.size() == 1) {
 		key_type = Type::INTEGER; // If no key type in array key = 0, 1, 2...

--- a/src/compiler/instruction/Instruction.hpp
+++ b/src/compiler/instruction/Instruction.hpp
@@ -14,7 +14,6 @@ class Instruction {
 public:
 
 	Type type = Type::VOID;
-	bool can_return = false;
 
 	virtual ~Instruction() = 0;
 

--- a/src/compiler/instruction/Return.cpp
+++ b/src/compiler/instruction/Return.cpp
@@ -14,7 +14,6 @@ Return::Return(Value* v) {
 	expression = v;
 	function = nullptr;
 	in_function = false;
-	can_return = true;
 }
 
 Return::~Return() {
@@ -29,22 +28,17 @@ void Return::print(ostream& os, int indent, bool debug) const {
 void Return::analyse(SemanticAnalyser* analyser, const Type& ) {
 
 	Function* f = analyser->current_function();
-	if (f != nullptr) {
-		if (f->type.getReturnType() == Type::UNKNOWN) {
-			expression->analyse(analyser, Type::UNKNOWN);
+	if (f->type.getReturnType() == Type::UNKNOWN) {
+		expression->analyse(analyser, Type::UNKNOWN);
 
-			f->type.setReturnType(Type::UNKNOWN); // ensure that the vector is not empty
-			f->type.return_types.push_back(expression->type);
-		} else {
-			expression->analyse(analyser, f->type.getReturnType());
-		}
-		function = f;
-		in_function = true;
+		f->type.setReturnType(Type::UNKNOWN); // ensure that the vector is not empty
+		f->type.return_types.push_back(expression->type);
 	} else {
-		expression->analyse(analyser, Type::POINTER);
-		function = nullptr;
-		in_function = false;
+		expression->analyse(analyser, f->type.getReturnType());
 	}
+	function = f;
+	in_function = true;
+
 	type = Type::VOID;
 }
 

--- a/src/compiler/instruction/Return.cpp
+++ b/src/compiler/instruction/Return.cpp
@@ -26,23 +26,26 @@ void Return::print(ostream& os, int indent, bool debug) const {
 	expression->print(os, indent, debug);
 }
 
-void Return::analyse(SemanticAnalyser* analyser, const Type& req_type) {
+void Return::analyse(SemanticAnalyser* analyser, const Type& ) {
 
-	expression->analyse(analyser, req_type);
 	Function* f = analyser->current_function();
+	expression->analyse(analyser, Type::POINTER);
 	if (f != nullptr) {
+		f->type.setReturnType(expression->type);
 		function = f;
 		in_function = true;
-//		f->can_return(expression->type);
+	} else {
+		function = nullptr;
+		in_function = false;
 	}
-	type = expression->type;
+	type = Type::VOID;
 }
 
 jit_value_t Return::compile(Compiler& c) const {
 
 	jit_value_t v = expression->compile(c);
 	jit_insn_return(c.F, v);
-	return v;
+	return nullptr;
 }
 
 }

--- a/src/compiler/instruction/Return.cpp
+++ b/src/compiler/instruction/Return.cpp
@@ -29,12 +29,19 @@ void Return::print(ostream& os, int indent, bool debug) const {
 void Return::analyse(SemanticAnalyser* analyser, const Type& ) {
 
 	Function* f = analyser->current_function();
-	expression->analyse(analyser, Type::POINTER);
 	if (f != nullptr) {
-		f->type.setReturnType(expression->type);
+		if (f->type.getReturnType() == Type::UNKNOWN) {
+			expression->analyse(analyser, Type::UNKNOWN);
+
+			f->type.setReturnType(Type::UNKNOWN); // ensure that the vector is not empty
+			f->type.return_types.push_back(expression->type);
+		} else {
+			expression->analyse(analyser, f->type.getReturnType());
+		}
 		function = f;
 		in_function = true;
 	} else {
+		expression->analyse(analyser, Type::POINTER);
 		function = nullptr;
 		in_function = false;
 	}

--- a/src/compiler/instruction/VariableDeclaration.cpp
+++ b/src/compiler/instruction/VariableDeclaration.cpp
@@ -45,6 +45,8 @@ void VariableDeclaration::print(ostream& os, int indent, bool debug) const {
 
 void VariableDeclaration::analyse(SemanticAnalyser* analyser, const Type&) {
 
+	type = Type::VOID;
+
 	vars.clear();
 	for (unsigned i = 0; i < variables.size(); ++i) {
 

--- a/src/compiler/instruction/VariableDeclaration.cpp
+++ b/src/compiler/instruction/VariableDeclaration.cpp
@@ -99,7 +99,7 @@ jit_value_t VariableDeclaration::compile(Compiler& c) const {
 			jit_value_t var = jit_value_create(c.F, JIT_POINTER);
 			c.add_var(name, var, Type::NULLL, false);
 
-			jit_value_t val = VM::create_null(c.F);
+			jit_value_t val = VM::get_null(c.F);
 			jit_insn_store(c.F, var, val);
 		}
 	}

--- a/src/compiler/instruction/While.cpp
+++ b/src/compiler/instruction/While.cpp
@@ -29,7 +29,7 @@ void While::print(ostream& os, int indent, bool debug) const {
 void While::analyse(SemanticAnalyser* analyser, const Type&) {
 
 	if (condition != nullptr) {
-		condition->analyse(analyser);
+		condition->analyse(analyser, Type::UNKNOWN);
 	}
 	analyser->enter_loop();
 	body->analyse(analyser, Type::VOID);

--- a/src/compiler/semantic/SemanticAnalyser.cpp
+++ b/src/compiler/semantic/SemanticAnalyser.cpp
@@ -118,9 +118,9 @@ void SemanticAnalyser::analyse(Program* program, Context* context, std::vector<M
 		program->main->type.return_types.clear();
 		program->main->type.setReturnType(return_type);
 		program->main->body->analyse(this, return_type); // second pass
+	} else {
+		program->main->type.setReturnType(program->main->body->type);
 	}
-
-	program->main->type.setReturnType(program->main->body->type);
 
 	program->functions = functions;
 }

--- a/src/compiler/semantic/SemanticAnalyser.cpp
+++ b/src/compiler/semantic/SemanticAnalyser.cpp
@@ -111,7 +111,7 @@ void SemanticAnalyser::analyse(Program* program, Context* context, std::vector<M
 	program->main->type.setReturnType(Type::UNKNOWN);
 	program->main->body->analyse(this, Type::UNKNOWN);
 	if (program->main->type.return_types.size() > 1) { // the body contains return instruction
-		Type return_type = program->main->body->type;
+		Type return_type = program->main->body->type == Type::VOID ? Type::UNKNOWN : program->main->body->type;
 		for (size_t i = 1; i < program->main->type.return_types.size(); ++i) {
 			return_type = Type::get_compatible_type(return_type, program->main->type.return_types[i]);
 		}

--- a/src/compiler/semantic/SemanticAnalyser.cpp
+++ b/src/compiler/semantic/SemanticAnalyser.cpp
@@ -107,6 +107,9 @@ void SemanticAnalyser::analyse(Program* program, Context* context, std::vector<M
 	in_program = true;
 
 	program->body->analyse(this, Type::UNKNOWN);
+	if (program->body->can_return) { // the body contains return instruction
+		program->body->analyse(this, Type::POINTER);
+	}
 
 	program->functions = functions;
 }

--- a/src/compiler/syntaxic/SyntaxicAnalyser.cpp
+++ b/src/compiler/syntaxic/SyntaxicAnalyser.cpp
@@ -667,7 +667,7 @@ Value* SyntaxicAnalyser::eatValue() {
 
 						eat(TokenType::ARROW);
 						l->body = new Block();
-						l->body->instructions.push_back(new Return(eatExpression()));
+						l->body->instructions.push_back(new ExpressionInstruction(eatExpression()));
 
 						return l;
 
@@ -708,7 +708,7 @@ Value* SyntaxicAnalyser::eatValue() {
 			l->lambda = true;
 			eat(TokenType::ARROW);
 			l->body = new Block();
-			l->body->instructions.push_back(new Return(eatExpression()));
+			l->body->instructions.push_back(new ExpressionInstruction(eatExpression()));
 			return l;
 		}
 

--- a/src/compiler/syntaxic/SyntaxicAnalyser.cpp
+++ b/src/compiler/syntaxic/SyntaxicAnalyser.cpp
@@ -63,7 +63,8 @@ Program* SyntaxicAnalyser::analyse(vector<Token>& tokens) {
 	this->i = 0;
 
 	Program* program = new Program();
-	program->body = eatMain();
+	program->main = new Function();
+	program->main->body = eatMain();
 
 	return program;
 }

--- a/src/compiler/value/ArrayAccess.cpp
+++ b/src/compiler/value/ArrayAccess.cpp
@@ -46,8 +46,8 @@ unsigned ArrayAccess::line() const {
 
 void ArrayAccess::analyse(SemanticAnalyser* analyser, const Type& req_type) {
 
-	array->analyse(analyser);
-	key->analyse(analyser);
+	array->analyse(analyser, Type::UNKNOWN);
+	key->analyse(analyser, Type::UNKNOWN);
 	constant = array->constant && key->constant;
 
 	if (array->type.raw_type == RawType::ARRAY || array->type.raw_type == RawType::INTERVAL) {

--- a/src/compiler/value/Block.cpp
+++ b/src/compiler/value/Block.cpp
@@ -48,8 +48,6 @@ void Block::analyse(SemanticAnalyser* analyser, const Type& req_type) {
 			instructions[i]->analyse(analyser, req_type);
 			type = instructions[i]->type;
 		}
-
-		can_return = can_return or instructions[i]->can_return;
 	}
 
 	analyser->leave_block();

--- a/src/compiler/value/Block.cpp
+++ b/src/compiler/value/Block.cpp
@@ -89,7 +89,7 @@ jit_value_t Block::compile(Compiler& c) const {
 	c.leave_block(c.F);
 
 	if (type.nature == Nature::POINTER) {
-		return VM::create_null(c.F);
+		return VM::get_null(c.F);
 	}
 	if (type.nature == Nature::VALUE) {
 		return jit_value_create_nint_constant(c.F, VM::get_jit_type(type), 0);

--- a/src/compiler/value/Function.cpp
+++ b/src/compiler/value/Function.cpp
@@ -129,7 +129,7 @@ void Function::analyse_body(SemanticAnalyser* analyser, const Type& req_type) {
 
 	type.setReturnType(Type::UNKNOWN);
 	body->analyse(analyser, req_type);
-	if (body->can_return) { // the body contains return instruction
+	if (type.return_types.size() > 1) { // the body contains return instruction
 		Type return_type = body->type;
 		for (size_t i = 1; i < type.return_types.size(); ++i) {
 			return_type = Type::get_compatible_type(return_type, type.return_types[i]);

--- a/src/compiler/value/Function.cpp
+++ b/src/compiler/value/Function.cpp
@@ -137,9 +137,9 @@ void Function::analyse_body(SemanticAnalyser* analyser, const Type& req_type) {
 		type.return_types.clear();
 		type.setReturnType(return_type);
 		body->analyse(analyser, return_type); // second pass
+	} else {
+		type.setReturnType(body->type);
 	}
-
-	type.setReturnType(body->type);
 
 	vars = analyser->get_local_vars();
 

--- a/src/compiler/value/Function.cpp
+++ b/src/compiler/value/Function.cpp
@@ -128,10 +128,13 @@ void Function::analyse_body(SemanticAnalyser* analyser, const Type& req_type) {
 	}
 
 	body->analyse(analyser, req_type);
-
-//	cout << "body type: " << body->type << endl;
-
-	type.setReturnType(body->type);
+	if (body->can_return) { // the body contains return instruction
+		// return instruction always return POINTERS
+		body->analyse(analyser, Type::POINTER);
+		type.setReturnType(Type::POINTER);
+	} else {
+		type.setReturnType(body->type);
+	}
 
 	vars = analyser->get_local_vars();
 

--- a/src/compiler/value/Function.cpp
+++ b/src/compiler/value/Function.cpp
@@ -130,7 +130,7 @@ void Function::analyse_body(SemanticAnalyser* analyser, const Type& req_type) {
 	type.setReturnType(Type::UNKNOWN);
 	body->analyse(analyser, req_type);
 	if (type.return_types.size() > 1) { // the body contains return instruction
-		Type return_type = body->type;
+		Type return_type = body->type == Type::VOID ? Type::UNKNOWN : body->type;
 		for (size_t i = 1; i < type.return_types.size(); ++i) {
 			return_type = Type::get_compatible_type(return_type, type.return_types[i]);
 		}
@@ -197,17 +197,6 @@ jit_value_t Function::compile(Compiler& c) const {
 
 	// Execute function
 	jit_value_t res = body->compile(c);
-	if (body->type.must_manage_memory()) {
-//		VM::dec_refs(function, res);
-	}
-
-	// Delete arguments
-	for (unsigned i = 0; i < arg_count; ++i) {
-		if (type.getArgumentType(i).must_manage_memory()) {
-			jit_value_t param = jit_value_get_param(function, i);
-//			VM::delete_obj(function, param);
-		}
-	}
 
 	// Return
 	jit_insn_return(function, res);

--- a/src/compiler/value/FunctionCall.cpp
+++ b/src/compiler/value/FunctionCall.cpp
@@ -67,7 +67,7 @@ void FunctionCall::analyse(SemanticAnalyser* analyser, const Type& req_type) {
 
 	constant = false;
 
-	function->analyse(analyser);
+	function->analyse(analyser, Type::UNKNOWN);
 
 	if (function->type.raw_type != RawType::UNKNOWN and function->type.raw_type != RawType::FUNCTION
 		and function->type.raw_type != RawType::CLASS) {
@@ -80,7 +80,7 @@ void FunctionCall::analyse(SemanticAnalyser* analyser, const Type& req_type) {
 	int a = 0;
 	for (Value* arg : arguments) {
 //		arg->analyse(analyser, function->type.getArgumentType(a++));
-		arg->analyse(analyser);
+		arg->analyse(analyser, Type::UNKNOWN);
 	}
 
 	// Standard library constructors
@@ -278,7 +278,7 @@ void FunctionCall::analyse(SemanticAnalyser* analyser, const Type& req_type) {
 			bool isByValue = true;
 			Type effectiveType;
 			for (Value* arg : arguments) {
-				arg->analyse(analyser);
+				arg->analyse(analyser, Type::UNKNOWN);
 				effectiveType = arg->type;
 				if (arg->type.nature != Nature::VALUE) {
 					isByValue = false;
@@ -323,7 +323,7 @@ void FunctionCall::analyse(SemanticAnalyser* analyser, const Type& req_type) {
 		}
 	}
 
-	return_type = type;
+	return_type = function->type.getReturnType();
 
 	if (req_type.nature != Nature::UNKNOWN) {
 		type.nature = req_type.nature;

--- a/src/compiler/value/If.cpp
+++ b/src/compiler/value/If.cpp
@@ -136,7 +136,7 @@ jit_value_t If::compile(Compiler& c) const {
 		}
 	} else {
 		if (type != Type::VOID) {
-			jit_insn_store(c.F, res, VM::create_null(c.F));
+			jit_insn_store(c.F, res, VM::get_null(c.F));
 		}
 	}
 

--- a/src/compiler/value/If.cpp
+++ b/src/compiler/value/If.cpp
@@ -51,7 +51,13 @@ void If::analyse(SemanticAnalyser* analyser, const Type& req_type) {
 
 		elze->analyse(analyser, req_type);
 
-		type = Type::get_compatible_type(then->type, elze->type);
+		if (then->type == Type::VOID) { // then contains return instruction
+			type = elze->type;
+		} else if (elze->type == Type::VOID) { // elze contains return instruction
+			type = then->type;
+		} else {
+			type = Type::get_compatible_type(then->type, elze->type);
+		}
 		if (then->type != type) {
 			then->analyse(analyser, type);
 		}
@@ -86,7 +92,11 @@ int is_true(LSValue* v) {
 
 jit_value_t If::compile(Compiler& c) const {
 
-	jit_value_t res = jit_value_create(c.F, JIT_POINTER);
+	jit_value_t res = nullptr;
+	if (type != Type::VOID) {
+		res = jit_value_create(c.F, VM::get_jit_type(type));
+	}
+
 	jit_label_t label_else = jit_label_undefined;
 	jit_label_t label_end = jit_label_undefined;
 
@@ -112,18 +122,16 @@ jit_value_t If::compile(Compiler& c) const {
 	}
 
 	jit_value_t then_v = then->compile(c);
-	jit_insn_store(c.F, res, then_v);
+	if (then_v) {
+		jit_insn_store(c.F, res, then_v);
+	}
 	jit_insn_branch(c.F, &label_end);
 
 	jit_insn_label(c.F, &label_else);
 
-//	if (then->type.must_manage_memory()) {
-//		VM::delete_temporary(c.F, then_v);
-//	}
-
 	if (elze != nullptr) {
 		jit_value_t else_v = elze->compile(c);
-		if (type != Type::VOID) {
+		if (else_v) {
 			jit_insn_store(c.F, res, else_v);
 		}
 	} else {

--- a/src/compiler/value/If.cpp
+++ b/src/compiler/value/If.cpp
@@ -47,12 +47,9 @@ void If::analyse(SemanticAnalyser* analyser, const Type& req_type) {
 	condition->analyse(analyser, Type::BOOLEAN);
 	then->analyse(analyser, req_type);
 
-	can_return = then->can_return;
-
 	if (elze != nullptr) {
 
 		elze->analyse(analyser, req_type);
-		can_return = can_return or elze->can_return;
 
 		type = Type::get_compatible_type(then->type, elze->type);
 		if (then->type != type) {

--- a/src/compiler/value/Map.cpp
+++ b/src/compiler/value/Map.cpp
@@ -56,11 +56,7 @@ void Map::analyse(SemanticAnalyser* analyser, const Type&) {
 		if (ex->constant == false) {
 			constant = false;
 		}
-		if (i == 0) {
-			key_type = ex->type;
-		} else {
-			key_type = Type::get_compatible_type(key_type, ex->type);
-		}
+		key_type = Type::get_compatible_type(key_type, ex->type);
 	}
 	for (size_t i = 0; i < values.size(); ++i) {
 		Value* ex = values[i];
@@ -69,11 +65,7 @@ void Map::analyse(SemanticAnalyser* analyser, const Type&) {
 		if (ex->constant == false) {
 			constant = false;
 		}
-		if (i == 0) {
-			value_type = ex->type;
-		} else {
-			value_type = Type::get_compatible_type(value_type, ex->type);
-		}
+		value_type = Type::get_compatible_type(value_type, ex->type);
 	}
 
 	if (key_type == Type::INTEGER) {
@@ -123,59 +115,16 @@ LSMap<int,double>* LSMap_create_int_float() {
 }
 
 void LSMap_insert_ptr_ptr(LSMap<LSValue*,LSValue*>* map, LSValue* key, LSValue* value) {
-	LSValue* key_copy;
-	LSValue* value_copy;
-	if (key->native) {
-		key_copy = key;
-	} else {
-		key_copy = key->clone();
-		key_copy->refs++;
-	}
-
-	if (value->native) {
-		value_copy = value;
-	} else {
-		value_copy = value->clone();
-		value_copy->refs++;
-	}
-	map->emplace(key_copy, value_copy);
-	LSValue::delete_val(key);
-	LSValue::delete_val(value);
+	map->emplace(key->move_inc(), value->move_inc());
 }
 void LSMap_insert_ptr_int(LSMap<LSValue*,int>* map, LSValue* key, int value) {
-	LSValue* key_copy;
-	if (key->native) {
-		key_copy = key;
-	} else {
-		key_copy = key->clone();
-		key_copy->refs++;
-	}
-
-	map->emplace(key_copy, value);
-	LSValue::delete_val(key);
+	map->emplace(key->move_inc(), value);
 }
 void LSMap_insert_ptr_float(LSMap<LSValue*,double>* map, LSValue* key, double value) {
-	LSValue* key_copy;
-	if (key->native) {
-		key_copy = key;
-	} else {
-		key_copy = key->clone();
-		key_copy->refs++;
-	}
-
-	map->emplace(key_copy, value);
-	LSValue::delete_val(key);
+	map->emplace(key->move_inc(), value);
 }
 void LSMap_insert_int_ptr(LSMap<int,LSValue*>* map, int key, LSValue* value) {
-	LSValue* value_copy;
-	if (value->native) {
-		value_copy = value;
-	} else {
-		value_copy = value->clone();
-		value_copy->refs++;
-	}
-	map->emplace(key, value_copy);
-	LSValue::delete_val(value);
+	map->emplace(key, value->move_inc());
 }
 void LSMap_insert_int_int(LSMap<int,int>* map, int key, int value) {
 	map->emplace(key, value);
@@ -217,14 +166,7 @@ jit_value_t Map::compile(Compiler &c) const {
 
 	for (size_t i = 0; i < keys.size(); ++i) {
 		jit_value_t k = keys[i]->compile(c);
-		if (type.element_types[0].must_manage_memory()) {
-			VM::inc_refs(c.F, k);
-		}
-
 		jit_value_t v = values[i]->compile(c);
-		if (type.element_types[1].must_manage_memory()) {
-			VM::inc_refs(c.F, v);
-		}
 
 		jit_type_t args[3] = {JIT_POINTER, key_type, value_type};
 		jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_void, args, 3, 0);

--- a/src/compiler/value/Map.cpp
+++ b/src/compiler/value/Map.cpp
@@ -115,22 +115,22 @@ LSMap<int,double>* LSMap_create_int_float() {
 }
 
 void LSMap_insert_ptr_ptr(LSMap<LSValue*,LSValue*>* map, LSValue* key, LSValue* value) {
-	map->emplace(key->move_inc(), value->move_inc());
+	map->ls_insert(key, value);
 }
 void LSMap_insert_ptr_int(LSMap<LSValue*,int>* map, LSValue* key, int value) {
-	map->emplace(key->move_inc(), value);
+	map->ls_insert(key, value);
 }
 void LSMap_insert_ptr_float(LSMap<LSValue*,double>* map, LSValue* key, double value) {
-	map->emplace(key->move_inc(), value);
+	map->ls_insert(key, value);
 }
 void LSMap_insert_int_ptr(LSMap<int,LSValue*>* map, int key, LSValue* value) {
-	map->emplace(key, value->move_inc());
+	map->ls_insert(key, value);
 }
 void LSMap_insert_int_int(LSMap<int,int>* map, int key, int value) {
-	map->emplace(key, value);
+	map->ls_insert(key, value);
 }
 void LSMap_insert_int_float(LSMap<int,double>* map, int key, double value) {
-	map->emplace(key, value);
+	map->ls_insert(key, value);
 }
 
 jit_value_t Map::compile(Compiler &c) const {
@@ -172,6 +172,13 @@ jit_value_t Map::compile(Compiler &c) const {
 		jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_void, args, 3, 0);
 		jit_value_t args_v[] = {map, k, v};
 		jit_insn_call_native(c.F, "insert", (void*) insert, sig, args_v, 3, JIT_CALL_NOTHROW); ops += std::log2(i + 1);
+
+		if (type.element_types[0].must_manage_memory()) {
+			VM::delete_temporary(c.F, k);
+		}
+		if (type.element_types[1].must_manage_memory()) {
+			VM::delete_temporary(c.F, v);
+		}
 	}
 
 	VM::inc_ops(c.F, ops);

--- a/src/compiler/value/Match.cpp
+++ b/src/compiler/value/Match.cpp
@@ -175,7 +175,7 @@ jit_value_t Match::compile(Compiler& c) const {
 	}
 	// In the case of no default pattern
 
-	jit_insn_store(c.F, res, VM::create_null(c.F));
+	jit_insn_store(c.F, res, VM::get_null(c.F));
 
 	jit_insn_label(c.F, &label_end);
 	if (value->type.must_manage_memory()) {

--- a/src/compiler/value/Nulll.cpp
+++ b/src/compiler/value/Nulll.cpp
@@ -29,7 +29,7 @@ void Nulll::analyse(SemanticAnalyser*, const Type&) {
 }
 
 jit_value_t Nulll::compile(Compiler& c) const {
-	return VM::create_null(c.F);
+	return VM::get_null(c.F);
 }
 
 }

--- a/src/compiler/value/ObjectAccess.cpp
+++ b/src/compiler/value/ObjectAccess.cpp
@@ -46,7 +46,7 @@ void ObjectAccess::analyse(SemanticAnalyser* analyser, const Type& req_type) {
 		field_string = new LSString(field->content);
 	}
 
-	object->analyse(analyser);
+	object->analyse(analyser, Type::UNKNOWN);
 
 	// Search direct attributes
 	try {

--- a/src/compiler/value/PostfixExpression.cpp
+++ b/src/compiler/value/PostfixExpression.cpp
@@ -31,7 +31,7 @@ unsigned PostfixExpression::line() const {
 }
 
 void PostfixExpression::analyse(SemanticAnalyser* analyser, const Type& req_type) {
-	expression->analyse(analyser);
+	expression->analyse(analyser, Type::UNKNOWN);
 	type = expression->type;
 	this->return_value = return_value;
 

--- a/src/compiler/value/PrefixExpression.cpp
+++ b/src/compiler/value/PrefixExpression.cpp
@@ -38,7 +38,7 @@ unsigned PrefixExpression::line() const {
 
 void PrefixExpression::analyse(SemanticAnalyser* analyser, const Type& req_type) {
 
-	expression->analyse(analyser);
+	expression->analyse(analyser, Type::UNKNOWN);
 
 	if (operatorr->type == TokenType::PLUS_PLUS
 		or operatorr->type == TokenType::MINUS_MINUS
@@ -63,7 +63,7 @@ void PrefixExpression::analyse(SemanticAnalyser* analyser, const Type& req_type)
 			if (VariableValue* vv = dynamic_cast<VariableValue*>(fc->function)) {
 				if (vv->name == "Number") {
 					if (fc->arguments.size() > 0) {
-						fc->arguments[0]->analyse(analyser);
+						fc->arguments[0]->analyse(analyser, Type::UNKNOWN);
 						type = fc->arguments[0]->type;
 					} else {
 						type = Type::INTEGER;

--- a/src/compiler/value/Value.cpp
+++ b/src/compiler/value/Value.cpp
@@ -10,10 +10,6 @@ Value::Value() {
 
 Value::~Value() {}
 
-void Value::analyse(SemanticAnalyser* analyser) {
-	analyse(analyser, Type::UNKNOWN);
-}
-
 bool Value::will_take(SemanticAnalyser*, const unsigned i, const Type arg_type) {
 	return type.will_take(i, arg_type);
 }

--- a/src/compiler/value/Value.hpp
+++ b/src/compiler/value/Value.hpp
@@ -33,7 +33,6 @@ public:
 	virtual bool will_take_element(SemanticAnalyser*, const Type);
 	virtual bool must_be_pointer(SemanticAnalyser*);
 	virtual void must_return(SemanticAnalyser*, const Type&);
-	void analyse(SemanticAnalyser*);
 	virtual void analyse(SemanticAnalyser*, const Type&) = 0;
 
 	virtual jit_value_t compile(Compiler&) const = 0;

--- a/src/compiler/value/Value.hpp
+++ b/src/compiler/value/Value.hpp
@@ -18,7 +18,6 @@ public:
 	std::map<std::string, Type> attr_types;
 	bool constant;
 	bool parenthesis = false;
-	bool can_return = false;
 
 	Value();
 	virtual ~Value();

--- a/src/vm/LSValue.cpp
+++ b/src/vm/LSValue.cpp
@@ -16,11 +16,14 @@ int LSValue::obj_count = 0;
 int LSValue::obj_deleted = 0;
 extern std::map<LSValue*, LSValue*> objs;
 
-LSValue::LSValue() {
-//	cout << "LSValue()" << endl;
-	native = false;
+LSValue::LSValue() : refs(0), native(false) {
 	obj_count++;
-//	objs.insert({this, this});
+	//	objs.insert({this, this});
+}
+
+LSValue::LSValue(const LSValue& other) : refs(0), native(other.native) {
+	obj_count++;
+	//	objs.insert({this, this});
 }
 
 LSValue::~LSValue() {

--- a/src/vm/LSValue.cpp
+++ b/src/vm/LSValue.cpp
@@ -20,7 +20,7 @@ LSValue::LSValue() {
 //	cout << "LSValue()" << endl;
 	native = false;
 	obj_count++;
-	objs.insert({this, this});
+//	objs.insert({this, this});
 }
 
 LSValue::~LSValue() {

--- a/src/vm/LSValue.hpp
+++ b/src/vm/LSValue.hpp
@@ -33,6 +33,7 @@ public:
 	bool native;
 
 	LSValue();
+	LSValue(const LSValue& other);
 	virtual ~LSValue() = 0;
 
 	virtual bool isTrue() const = 0;

--- a/src/vm/Program.cpp
+++ b/src/vm/Program.cpp
@@ -76,6 +76,9 @@ LSValue* Program::execute() {
 
 void Program::print(ostream& os, bool debug) const {
 	main->body->print(os, 0, debug);
+	if (debug) {
+		os << "\n" << main->type;
+	}
 	cout << endl;
 }
 

--- a/src/vm/Program.hpp
+++ b/src/vm/Program.hpp
@@ -15,7 +15,7 @@ public:
 
 	std::vector<Function*> functions;
 	std::map<std::string, LSValue*> system_vars;
-	Block* body;
+	Function* main;
 	void* closure;
 
 	Program();

--- a/src/vm/Type.cpp
+++ b/src/vm/Type.cpp
@@ -231,8 +231,8 @@ bool Type::operator == (const Type& type) const {
 	if (this->return_types != type.return_types) return false;
 	if (this->arguments_types != type.arguments_types) return false;
 
-	if (this->element_types.size() > 0 and type.element_types.size() > 0 and
-		this->element_types != type.element_types) return false;
+	if (/*this->element_types.size() > 0 and type.element_types.size() > 0 and
+		*/this->element_types != type.element_types) return false;
 
 	return true;
 }
@@ -366,7 +366,15 @@ Type Type::get_compatible_type(const Type& old_type, const Type& new_type) {
 	}
 
 	if (old_type.nature == Nature::POINTER and new_type.nature == Nature::VALUE) {
-		return old_type;
+		if (old_type.raw_type == new_type.raw_type) {
+			if (old_type.element_types == new_type.element_types
+					&& old_type.return_types == new_type.return_types
+					&& old_type.arguments_types == new_type.arguments_types) {
+				return old_type; // They are identical except the Nature
+			}
+			return Type(old_type.raw_type, Nature::POINTER); // They have the same raw_type
+		}
+		return Type::POINTER;
 	}
 
 	if (old_type.raw_type == RawType::UNKNOWN) {

--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -456,13 +456,8 @@ void VM::print_int(jit_function_t F, jit_value_t val) {
 	jit_insn_call_native(F, "print_int", (void*) VM_print_int, sig, &val, 1, JIT_CALL_NOTHROW);
 }
 
-LSValue* VM_create_null() {
-	return LSNull::get();
-}
-
-jit_value_t VM::create_null(jit_function_t F) {
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_POINTER, {}, 0, 0);
-	return jit_insn_call_native(F, "create_null", (void*) VM_create_null, sig, {}, 0, JIT_CALL_NOTHROW);
+jit_value_t VM::get_null(jit_function_t F) {
+	return JIT_CREATE_CONST_POINTER(F, LSNull::get());
 }
 
 LSValue* VM_move(LSValue* val) {

--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -97,7 +97,7 @@ string VM::execute(const std::string code, std::string ctx, ExecMode mode) {
 	/*
 	 * Debug
 	 */
-	cout << "Program: "; program->print(cout, true);
+//	cout << "Program: "; program->print(cout, true);
 
 	// Compilation
 	internals.clear();

--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -97,7 +97,7 @@ string VM::execute(const std::string code, std::string ctx, ExecMode mode) {
 	/*
 	 * Debug
 	 */
-//	cout << "Program: "; program->print(cout, true);
+	cout << "Program: "; program->print(cout, true);
 
 	// Compilation
 	internals.clear();

--- a/src/vm/VM.hpp
+++ b/src/vm/VM.hpp
@@ -74,7 +74,7 @@ public:
 	static void inc_ops(jit_function_t F, int add);
 	static void get_operations(jit_function_t F);
 	static void print_int(jit_function_t F, jit_value_t val);
-	static jit_value_t create_null(jit_function_t F);
+	static jit_value_t get_null(jit_function_t F);
 	static jit_value_t move_obj(jit_function_t F, jit_value_t obj);
 };
 

--- a/src/vm/standard/ArraySTD.cpp
+++ b/src/vm/standard/ArraySTD.cpp
@@ -24,9 +24,9 @@ ArraySTD::ArraySTD() : Module("Array") {
 	});
 
 	method("size", {
-		{Type::ARRAY, Type::INTEGER, {}, (void*) &LSArray<LSValue*>::size},
-		{Type::FLOAT_ARRAY, Type::INTEGER, {}, (void*) &LSArray<float>::size},
-		{Type::INT_ARRAY, Type::INTEGER, {}, (void*) &LSArray<int>::size}
+		{Type::ARRAY, Type::INTEGER, {}, (void*) &LSArray<LSValue*>::ls_size},
+		{Type::FLOAT_ARRAY, Type::INTEGER, {}, (void*) &LSArray<double>::ls_size},
+		{Type::INT_ARRAY, Type::INTEGER, {}, (void*) &LSArray<int>::ls_size}
 	});
 
 	method("sum", {
@@ -48,35 +48,26 @@ ArraySTD::ArraySTD() : Module("Array") {
 		{Type::ARRAY, Type::ARRAY, {map_fun_type}, (void*) &LSArray<LSValue*>::map},
 	});
 
-	Type array_array = Type::ARRAY;
-	array_array.setElementType(Type::ARRAY);
-
-	Type int_array_array = Type::ARRAY;
-	int_array_array.setElementType(Type::INT_ARRAY);
-
-	Type float_array_array = Type::ARRAY;
-	float_array_array.setElementType(Type::FLOAT_ARRAY);
-
 	method("chunk", {
-		{Type::ARRAY, array_array, {}, (void*) array_chunk_1_ptr},
-		{Type::FLOAT_ARRAY, float_array_array, {}, (void*) array_chunk_1_float},
-		{Type::INT_ARRAY, int_array_array, {}, (void*) array_chunk_1_int},
+		{Type::ARRAY, Type::ARRAY, {}, (void*) array_chunk_1_ptr},
+		{Type::FLOAT_ARRAY, Type::FLOAT_ARRAY, {}, (void*) array_chunk_1_float},
+		{Type::INT_ARRAY, Type::INT_ARRAY, {}, (void*) array_chunk_1_int},
 
-		{Type::ARRAY, array_array, {Type::INTEGER}, (void*) &LSArray<LSValue*>::chunk},
-		{Type::FLOAT_ARRAY, float_array_array, {Type::INTEGER}, (void*) &LSArray<double>::chunk},
-		{Type::INT_ARRAY, int_array_array, {Type::INTEGER}, (void*) &LSArray<int>::chunk},
+		{Type::ARRAY, Type::ARRAY, {Type::INTEGER}, (void*) &LSArray<LSValue*>::ls_chunk},
+		{Type::FLOAT_ARRAY, Type::FLOAT_ARRAY, {Type::INTEGER}, (void*) &LSArray<double>::ls_chunk},
+		{Type::INT_ARRAY, Type::INT_ARRAY, {Type::INTEGER}, (void*) &LSArray<int>::ls_chunk},
     });
 
 	method("unique", {
-		{Type::ARRAY, Type::ARRAY, {}, (void*) &LSArray<LSValue*>::unique},
-		{Type::FLOAT_ARRAY, Type::FLOAT_ARRAY, {}, (void*) &LSArray<double>::unique},
-		{Type::INT_ARRAY, Type::INT_ARRAY, {}, (void*) &LSArray<int>::unique},
+		{Type::ARRAY, Type::VOID, {}, (void*) &LSArray<LSValue*>::ls_unique},
+		{Type::FLOAT_ARRAY, Type::VOID, {}, (void*) &LSArray<double>::ls_unique},
+		{Type::INT_ARRAY, Type::VOID, {}, (void*) &LSArray<int>::ls_unique},
 	});
 
 	method("sort", {
-		{Type::ARRAY, Type::ARRAY, {}, (void*) &LSArray<LSValue*>::sort},
-		{Type::FLOAT_ARRAY, Type::FLOAT_ARRAY, {}, (void*) &LSArray<double>::sort},
-		{Type::INT_ARRAY, Type::INT_ARRAY, {}, (void*) &LSArray<int>::sort},
+		{Type::ARRAY, Type::VOID, {}, (void*) &LSArray<LSValue*>::ls_sort},
+		{Type::FLOAT_ARRAY, Type::VOID, {}, (void*) &LSArray<double>::ls_sort},
+		{Type::INT_ARRAY, Type::VOID, {}, (void*) &LSArray<int>::ls_sort},
 	});
 
 	Type map2_fun_type = Type::FUNCTION;
@@ -155,7 +146,7 @@ ArraySTD::ArraySTD() : Module("Array") {
 	});
 
 	method("pop", {
-		{Type::ARRAY, Type::POINTER, {}, (void*) &LSArray<LSValue*>::pop}
+		{Type::ARRAY, Type::POINTER, {}, (void*) &LSArray<LSValue*>::ls_pop}
 	});
 
 	method("push", {
@@ -216,9 +207,9 @@ ArraySTD::ArraySTD() : Module("Array") {
 	static_method("min", Type::INTEGER_P, {Type::ARRAY}, (void*) &array_min);
 
 	static_method("size", {
-		{Type::INTEGER, {Type::ARRAY}, (void*) &LSArray<LSValue*>::size},
-		{Type::INTEGER, {Type::FLOAT_ARRAY}, (void*) &LSArray<float>::size},
-		{Type::INTEGER, {Type::INT_ARRAY}, (void*) &LSArray<int>::size}
+		{Type::INTEGER, {Type::ARRAY}, (void*) &LSArray<LSValue*>::ls_size},
+		{Type::INTEGER, {Type::FLOAT_ARRAY}, (void*) &LSArray<double>::ls_size},
+		{Type::INTEGER, {Type::INT_ARRAY}, (void*) &LSArray<int>::ls_size}
 	});
 
 	static_method("sum", {
@@ -280,8 +271,9 @@ ArraySTD::ArraySTD() : Module("Array") {
 	});
 
 	static_method("pop", {
-		{Type::POINTER, {Type::ARRAY}, (void*) &LSArray<LSValue*>::pop},
-		{Type::INTEGER, {Type::INT_ARRAY}, (void*) &LSArray<int>::pop}
+		{Type::POINTER, {Type::ARRAY}, (void*) &LSArray<LSValue*>::ls_pop},
+		{Type::INTEGER, {Type::FLOAT_ARRAY}, (void*) &LSArray<double>::ls_pop},
+		{Type::INTEGER, {Type::INT_ARRAY}, (void*) &LSArray<int>::ls_pop}
 	});
 
 	static_method("push", {
@@ -382,11 +374,6 @@ LSValue* array_insert(LSArray<LSValue*>* array, const LSValue* element, const LS
 
 LSValue* array_isEmpty(const LSArray<LSValue*>* array) {
 	return LSBoolean::get(array->size() == 0);
-}
-
-LSValue* array_keySort(const LSArray<LSValue*>*, const LSNumber*) {
-	// TODO
-	return new LSArray<LSValue*>();
 }
 
 LSValue* array_last(const LSArray<LSValue*>* array) {
@@ -507,11 +494,6 @@ LSArray<LSValue*>* array_shuffle(const LSArray<LSValue*>*) {
 	return new_array;
 }
 
-LSArray<LSValue*>* array_sort(const LSArray<LSValue*>*, const LSNumber*) {
-	// TODO
-	return new LSArray<LSValue*>();
-}
-
 LSValue* array_sum(const LSArray<LSValue*>*) {
 //	return LSNumber::get(array->sum());
 	return LSNumber::get(0);
@@ -523,15 +505,15 @@ LSValue* array_unshift(const LSArray<LSValue*>*, const LSValue*) {
 }
 
 LSArray<LSValue*>* array_chunk_1_ptr(const LSArray<LSValue*>* array) {
-	return array->chunk(1);
+	return array->ls_chunk(1);
 }
 
 LSArray<LSValue*>* array_chunk_1_int(const LSArray<int>* array) {
-	return array->chunk(1);
+	return array->ls_chunk(1);
 }
 
 LSArray<LSValue*>* array_chunk_1_float(const LSArray<double>* array) {
-	return array->chunk(1);
+	return array->ls_chunk(1);
 }
 
 }

--- a/src/vm/standard/MapSTD.cpp
+++ b/src/vm/standard/MapSTD.cpp
@@ -12,12 +12,12 @@ MapSTD::MapSTD() : Module("Map") {
 	method("size", Type::MAP, Type::INTEGER, {}, (void*) map_size);
 
 	method("insert", {
-			   {Type::PTR_PTR_MAP, Type::PTR_PTR_MAP, {Type::POINTER, Type::POINTER}, (void*) &LSMap<LSValue*,LSValue*>::ls_insert},
-			   {Type::PTR_FLOAT_MAP, Type::PTR_FLOAT_MAP, {Type::POINTER, Type::FLOAT}, (void*) &LSMap<LSValue*,double>::ls_insert},
-			   {Type::PTR_INT_MAP, Type::PTR_INT_MAP, {Type::POINTER, Type::INTEGER}, (void*) &LSMap<LSValue*,int>::ls_insert},
-			   {Type::INT_PTR_MAP, Type::INT_PTR_MAP, {Type::INTEGER, Type::POINTER}, (void*) &LSMap<int,LSValue*>::ls_insert},
-			   {Type::INT_FLOAT_MAP, Type::INT_FLOAT_MAP, {Type::INTEGER, Type::FLOAT}, (void*) &LSMap<int,double>::ls_insert},
-			   {Type::INT_INT_MAP, Type::INT_INT_MAP, {Type::INTEGER, Type::INTEGER}, (void*) &LSMap<int,int>::ls_insert},
+			   {Type::PTR_PTR_MAP, Type::BOOLEAN, {Type::POINTER, Type::POINTER}, (void*) &LSMap<LSValue*,LSValue*>::ls_insert},
+			   {Type::PTR_FLOAT_MAP, Type::BOOLEAN, {Type::POINTER, Type::FLOAT}, (void*) &LSMap<LSValue*,double>::ls_insert},
+			   {Type::PTR_INT_MAP, Type::BOOLEAN, {Type::POINTER, Type::INTEGER}, (void*) &LSMap<LSValue*,int>::ls_insert},
+			   {Type::INT_PTR_MAP, Type::BOOLEAN, {Type::INTEGER, Type::POINTER}, (void*) &LSMap<int,LSValue*>::ls_insert},
+			   {Type::INT_FLOAT_MAP, Type::BOOLEAN, {Type::INTEGER, Type::FLOAT}, (void*) &LSMap<int,double>::ls_insert},
+			   {Type::INT_INT_MAP, Type::BOOLEAN, {Type::INTEGER, Type::INTEGER}, (void*) &LSMap<int,int>::ls_insert},
 		   });
 
 
@@ -31,21 +31,21 @@ MapSTD::MapSTD() : Module("Map") {
 		   });
 
 	method("erase", {
-			   {Type::PTR_PTR_MAP, Type::PTR_PTR_MAP, {Type::POINTER}, (void*) &LSMap<LSValue*,LSValue*>::ls_erase},
-			   {Type::PTR_FLOAT_MAP, Type::PTR_FLOAT_MAP, {Type::POINTER}, (void*) &LSMap<LSValue*,double>::ls_erase},
-			   {Type::PTR_INT_MAP, Type::PTR_INT_MAP, {Type::POINTER}, (void*) &LSMap<LSValue*,int>::ls_erase},
-			   {Type::INT_PTR_MAP, Type::INT_PTR_MAP, {Type::INTEGER}, (void*) &LSMap<int,LSValue*>::ls_erase},
-			   {Type::INT_FLOAT_MAP, Type::INT_FLOAT_MAP, {Type::INTEGER}, (void*) &LSMap<int,double>::ls_erase},
-			   {Type::INT_INT_MAP, Type::INT_INT_MAP, {Type::INTEGER}, (void*) &LSMap<int,int>::ls_erase},
+			   {Type::PTR_PTR_MAP, Type::BOOLEAN, {Type::POINTER}, (void*) &LSMap<LSValue*,LSValue*>::ls_erase},
+			   {Type::PTR_FLOAT_MAP, Type::BOOLEAN, {Type::POINTER}, (void*) &LSMap<LSValue*,double>::ls_erase},
+			   {Type::PTR_INT_MAP, Type::BOOLEAN, {Type::POINTER}, (void*) &LSMap<LSValue*,int>::ls_erase},
+			   {Type::INT_PTR_MAP, Type::BOOLEAN, {Type::INTEGER}, (void*) &LSMap<int,LSValue*>::ls_erase},
+			   {Type::INT_FLOAT_MAP, Type::BOOLEAN, {Type::INTEGER}, (void*) &LSMap<int,double>::ls_erase},
+			   {Type::INT_INT_MAP, Type::BOOLEAN, {Type::INTEGER}, (void*) &LSMap<int,int>::ls_erase},
 		   });
 
 	method("look", {
-			   {Type::PTR_PTR_MAP, Type::PTR_PTR_MAP, {Type::POINTER, Type::POINTER}, (void*) &LSMap<LSValue*,LSValue*>::ls_look},
-			   {Type::PTR_FLOAT_MAP, Type::PTR_FLOAT_MAP, {Type::POINTER, Type::FLOAT}, (void*) &LSMap<LSValue*,double>::ls_look},
-			   {Type::PTR_INT_MAP, Type::PTR_INT_MAP, {Type::POINTER, Type::INTEGER}, (void*) &LSMap<LSValue*,int>::ls_look},
-			   {Type::INT_PTR_MAP, Type::INT_PTR_MAP, {Type::INTEGER, Type::POINTER}, (void*) &LSMap<int,LSValue*>::ls_look},
-			   {Type::INT_FLOAT_MAP, Type::INT_FLOAT_MAP, {Type::INTEGER, Type::FLOAT}, (void*) &LSMap<int,double>::ls_look},
-			   {Type::INT_INT_MAP, Type::INT_INT_MAP, {Type::INTEGER, Type::INTEGER}, (void*) &LSMap<int,int>::ls_look},
+			   {Type::PTR_PTR_MAP, Type::POINTER, {Type::POINTER, Type::POINTER}, (void*) &LSMap<LSValue*,LSValue*>::ls_look},
+			   {Type::PTR_FLOAT_MAP, Type::FLOAT, {Type::POINTER, Type::FLOAT}, (void*) &LSMap<LSValue*,double>::ls_look},
+			   {Type::PTR_INT_MAP, Type::INTEGER, {Type::POINTER, Type::INTEGER}, (void*) &LSMap<LSValue*,int>::ls_look},
+			   {Type::INT_PTR_MAP, Type::POINTER, {Type::INTEGER, Type::POINTER}, (void*) &LSMap<int,LSValue*>::ls_look},
+			   {Type::INT_FLOAT_MAP, Type::FLOAT, {Type::INTEGER, Type::FLOAT}, (void*) &LSMap<int,double>::ls_look},
+			   {Type::INT_INT_MAP, Type::INTEGER, {Type::INTEGER, Type::INTEGER}, (void*) &LSMap<int,int>::ls_look},
 		   });
 }
 

--- a/src/vm/value/LSArray.hpp
+++ b/src/vm/value/LSArray.hpp
@@ -38,8 +38,8 @@ public:
 	T remove(const int index);
 	T remove_key(LSValue* key);
 	T remove_element(T element);
-	LSValue* pop();
-	virtual size_t size() const;
+	LSValue* ls_pop();
+	int ls_size();
 	virtual T sum() const;
 	virtual double average() const;
 	virtual T first() const;
@@ -49,9 +49,9 @@ public:
 	LSArray<LSValue*>* map(const void*) const;
 	LSArray<int>* map_int(const void*) const;
 	LSArray<double>* map_real(const void*) const;
-	LSArray<LSValue*>* chunk(int size = 1) const;
-	LSArray<T>* unique();
-	LSArray<T>* sort();
+	LSArray<LSValue*>* ls_chunk(int size = 1) const;
+	void ls_unique();
+	void ls_sort();
 	void iter(const LSFunction*) const;
 	int contains(const LSValue*) const;
 	int contains_int(int) const;

--- a/src/vm/value/LSArray.tcc
+++ b/src/vm/value/LSArray.tcc
@@ -1374,8 +1374,8 @@ LSValue* LSArray<T>::clone() const {
 	return new_array;
 }
 
-template <class T>
-std::ostream& LSArray<T>::print(std::ostream& os) const {
+template <>
+inline std::ostream& LSArray<LSValue*>::print(std::ostream& os) const {
 	os << "[";
 	for (auto i = this->begin(); i != this->end(); i++) {
 		if (i != this->begin()) os << ", ";

--- a/src/vm/value/LSArray.tcc
+++ b/src/vm/value/LSArray.tcc
@@ -38,9 +38,7 @@ inline void LSArray<LSValue*>::push_move(LSValue* value) {
 	if (value->native) {
 		this->push_back(value); // no clone if native value
 	} else {
-		LSValue* val = value->move();
-		val->refs++;
-		this->push_back(val);
+		this->push_back(value->move_inc());
 	}
 }
 template <>
@@ -156,13 +154,8 @@ inline int LSArray<int>::remove_element(int element) {
 }
 
 template <class T>
-inline size_t LSArray<T>::size() const {
-	return ((std::vector<T>*) this)->size();
-}
-
-template <class T>
 T LSArray<T>::sum() const {
-	if (size() == 0) return (T) LSNumber::get(0);
+	if (this->size() == 0) return (T) LSNumber::get(0);
 	LSValue* sum = this->operator [] (0)->clone();
 	for (unsigned i = 1; i < this->size(); ++i) {
 		LSValue* new_sum = (*this)[i]->operator + (sum);
@@ -209,34 +202,48 @@ inline double LSArray<int>::average() const {
 
 template <class T>
 T LSArray<T>::first() const {
-	if (size() == 0) return T();
+	if (this->size() == 0) return T();
 	return this->operator [] (0);
 }
 
 template <class T>
 T LSArray<T>::last() const {
-	if (size() == 0) return T();
+	if (this->size() == 0) return T();
 	return this->back();
 }
 
-template <class T>
-LSValue* LSArray<T>::pop() {
-	LSValue* last = LSNull::get();
-	if (this->size() > 0) {
-		last = this->back();
-		this->pop_back();
+template <>
+inline LSValue* LSArray<LSValue*>::ls_pop() {
+	if (empty()) {
+		return LSNull::get();
 	}
+	LSValue* last = back();
+	last->refs--;
+	pop_back();
+	return last;
+}
+template <>
+inline LSValue* LSArray<int>::ls_pop() {
+	if (empty()) {
+		return LSNull::get();
+	}
+	LSValue* last = LSNumber::get(back());
+	pop_back();
+	return last;
+}
+template <>
+inline LSValue* LSArray<double>::ls_pop() {
+	if (empty()) {
+		return LSNull::get();
+	}
+	LSValue* last = LSNumber::get(back());
+	pop_back();
 	return last;
 }
 
-template <>
-inline LSValue* LSArray<int>::pop() {
-	if (this->size() > 0) {
-		int last = this->back();
-		this->pop_back();
-		return LSNumber::get(last);
-	}
-	return LSNull::get();
+template <typename T>
+inline int LSArray<T>::ls_size() {
+	return this->size();
 }
 
 template <>
@@ -319,7 +326,7 @@ inline LSArray<int>* LSArray<double>::map_int(const void* function) const {
 
 
 template <typename T>
-inline LSArray<LSValue*>* LSArray<T>::chunk(int size) const {
+inline LSArray<LSValue*>* LSArray<T>::ls_chunk(int size) const {
 	if (size <= 0) size = 1;
 
 	LSArray<LSValue*>* new_array = new LSArray<LSValue*>();
@@ -342,9 +349,8 @@ inline LSArray<LSValue*>* LSArray<T>::chunk(int size) const {
 }
 
 template <>
-inline LSArray<LSValue*>* LSArray<LSValue*>::unique() {
-	this->refs++;
-	if (this->empty()) return this;
+inline void LSArray<LSValue*>::ls_unique() {
+	if (this->empty()) return;
 
 	auto it = this->begin();
 	auto next = it;
@@ -352,7 +358,8 @@ inline LSArray<LSValue*>* LSArray<LSValue*>::unique() {
 	while (true) {
 		++next;
 		while (next != this->end() && (*next)->operator == (*it)) {
-			LSValue::delete_val(*next++);
+			LSValue::delete_val(*next);
+			next++;
 		}
 		++it;
 		if (next == this->end()) {
@@ -361,46 +368,31 @@ inline LSArray<LSValue*>* LSArray<LSValue*>::unique() {
 		*it = *next;
 	}
 	this->resize(std::distance(this->begin(), it));
-	return this;
 }
-
 template <>
-inline LSArray<int>* LSArray<int>::unique() {
+inline void LSArray<int>::ls_unique() {
 	auto it = std::unique(this->begin(), this->end());
 	this->resize(std::distance(this->begin(), it));
-	this->refs++;
-	return this;
 }
-
 template <>
-inline LSArray<double>* LSArray<double>::unique() {
+inline void LSArray<double>::ls_unique() {
 	auto it = std::unique(this->begin(), this->end());
 	this->resize(std::distance(this->begin(), it));
-	this->refs++;
-	return this;
 }
 
 template <>
-inline LSArray<LSValue*>* LSArray<LSValue*>::sort() {
+inline void LSArray<LSValue*>::ls_sort() {
 	std::sort(this->begin(), this->end(), [](LSValue* a, LSValue* b) -> bool {
 		return b->operator < (a);
 	});
-	this->refs++;
-	return this;
 }
-
 template <>
-inline LSArray<int>* LSArray<int>::sort() {
+inline void LSArray<int>::ls_sort() {
 	std::sort(this->begin(), this->end());
-	this->refs++;
-	return this;
 }
-
 template <>
-inline LSArray<double>* LSArray<double>::sort() {
+inline void LSArray<double>::ls_sort() {
 	std::sort(this->begin(), this->end());
-	this->refs++;
-	return this;
 }
 
 template <class T>
@@ -443,7 +435,6 @@ inline int LSArray<int>::contains_int(int val) const {
 template <class T>
 LSArray<T>* LSArray<T>::push(const T val) {
 	push_clone(val);
-	if (this->refs == 0) refs = 1;
 	return this;
 }
 
@@ -452,7 +443,6 @@ LSArray<T>* LSArray<T>::push_all(const LSArray<LSValue*>* array) {
 	for (auto v : *array) {
 		push_clone((T) v);
 	}
-	if (this->refs == 0) refs = 1;
 	return this;
 }
 
@@ -461,7 +451,6 @@ inline const LSArray<int>* LSArray<int>::push_all_int(const LSArray<int>* array)
 	for (auto v : *array) {
 		push_clone(v);
 	}
-	if (this->refs == 0) refs = 1;
 	return this;
 }
 
@@ -557,7 +546,6 @@ LSArray<T>* LSArray<T>::insert_v(const T v, const LSValue* pos) {
 		}
 		this->insert(this->begin() + (int) n->value, v);
 	}
-	this->refs++;
 	return this;
 }
 
@@ -569,7 +557,6 @@ inline LSArray<int>* LSArray<int>::insert_v(const int v, const LSValue* pos) {
 		}
 		this->insert(this->begin() + (int) n->value, (int) v);
 	}
-	this->refs++;
 	return this;
 }
 
@@ -750,7 +737,6 @@ LSArray<T>* LSArray<T>::fill(const LSValue* element, const int size) {
 	for (int i = 0; i < size; i++) {
 		this->push_clone((LSValue*) element);
 	}
-	this->refs++;
 	return this;
 }
 
@@ -760,7 +746,6 @@ inline LSArray<int>* LSArray<int>::fill(const LSValue* element, const int size) 
 	for (int i = 0; i < size; i++) {
 		this->push_clone(((LSNumber*) element)->value);
 	}
-	this->refs++;
 	return this;
 }
 
@@ -1335,7 +1320,7 @@ LSValue* LSArray<T>::range(int start, int end) const {
 	LSArray<T>* range = new LSArray<T>();
 
 	unsigned start_i = std::max(0, (int) start);
-	unsigned end_i = std::min((int) size() - 1, (int) end);
+	unsigned end_i = std::min((int) this->size() - 1, (int) end);
 
 	for (unsigned i = start_i; i <= end_i; i++) {
 		range->push_clone(this->operator [] (i));
@@ -1553,7 +1538,7 @@ LSValue** LSArray<T>::attrL(const LSValue*) {
 
 template <class T>
 LSValue* LSArray<T>::abso() const {
-	return LSNumber::get(size());
+	return LSNumber::get(this->size());
 }
 
 } // end of namespace ls

--- a/src/vm/value/LSMap.hpp
+++ b/src/vm/value/LSMap.hpp
@@ -25,9 +25,9 @@ public:
 	/*
 	 * Map methods;
 	 */
-	LSMap<K,T>* ls_insert(K key, T value);
+	bool ls_insert(K key, T value);
 	LSMap<K,T>* ls_clear();
-	LSMap<K,T>* ls_erase(K key);
+	bool ls_erase(K key);
 	T ls_look(K key, T def);
 
 	/*

--- a/src/vm/value/LSMap.tcc
+++ b/src/vm/value/LSMap.tcc
@@ -63,40 +63,48 @@ inline LSMap<int,double>::~LSMap() {}
  * Map methods
  */
 template <>
-inline LSMap<LSValue*,LSValue*>* LSMap<LSValue*,LSValue*>::ls_insert(LSValue* key, LSValue* value) {
-	emplace(key->move_inc(), value->move_inc());
-	if (refs == 0) refs = 1;
-	return this;
+inline bool LSMap<LSValue*,LSValue*>::ls_insert(LSValue* key, LSValue* value) {
+	auto it = lower_bound(key);
+	if (it == end() || it->first->operator !=(key)) {
+		emplace_hint(it, key->move_inc(), value->move_inc());
+		return true;
+	}
+	return false;
 }
 template <>
-inline LSMap<LSValue*,int>* LSMap<LSValue*,int>::ls_insert(LSValue* key, int value) {
-	emplace(key->move_inc(), value);
-	if (refs == 0) refs = 1;
-	return this;
+inline bool LSMap<LSValue*,int>::ls_insert(LSValue* key, int value) {
+	auto it = lower_bound(key);
+	if (it == end() || it->first->operator !=(key)) {
+		emplace_hint(it, key->move_inc(), value);
+		return true;
+	}
+	return false;
 }
 template <>
-inline LSMap<LSValue*,double>* LSMap<LSValue*,double>::ls_insert(LSValue* key, double value) {
-	emplace(key->move_inc(), value);
-	if (refs == 0) refs = 1;
-	return this;
+inline bool LSMap<LSValue*,double>::ls_insert(LSValue* key, double value) {
+	auto it = lower_bound(key);
+	if (it == end() || it->first->operator !=(key)) {
+		emplace_hint(it, key->move_inc(), value);
+		return true;
+	}
+	return false;
 }
 template <>
-inline LSMap<int,LSValue*>* LSMap<int,LSValue*>::ls_insert(int key, LSValue* value) {
-	emplace(key, value->move_inc());
-	if (refs == 0) refs = 1;
-	return this;
+inline bool LSMap<int,LSValue*>::ls_insert(int key, LSValue* value) {
+	auto it = lower_bound(key);
+	if (it == end() || it->first != key) {
+		emplace_hint(it, key, value->move_inc());
+		return true;
+	}
+	return false;
 }
 template <>
-inline LSMap<int,int>* LSMap<int,int>::ls_insert(int key, int value) {
-	emplace(key, value);
-	if (refs == 0) refs = 1;
-	return this;
+inline bool LSMap<int,int>::ls_insert(int key, int value) {
+	return emplace(key, value).second;
 }
 template <>
-inline LSMap<int,double>* LSMap<int,double>::ls_insert(int key, double value) {
-	emplace(key, value);
-	if (refs == 0) refs = 1;
-	return this;
+inline bool LSMap<int,double>::ls_insert(int key, double value) {
+	return emplace(key, value).second;
 }
 
 
@@ -107,7 +115,6 @@ inline LSMap<LSValue*,LSValue*>* LSMap<LSValue*,LSValue*>::ls_clear() {
 		LSValue::delete_val(it->second);
 	}
 	clear();
-	if (refs == 0) refs = 1;
 	return this;
 }
 template <>
@@ -116,7 +123,6 @@ inline LSMap<LSValue*,int>* LSMap<LSValue*,int>::ls_clear() {
 		LSValue::delete_val(it->first);
 	}
 	clear();
-	if (refs == 0) refs = 1;
 	return this;
 }
 template <>
@@ -125,7 +131,6 @@ inline LSMap<LSValue*,double>* LSMap<LSValue*,double>::ls_clear() {
 		LSValue::delete_val(it->first);
 	}
 	clear();
-	if (refs == 0) refs = 1;
 	return this;
 }
 template <>
@@ -134,74 +139,67 @@ inline LSMap<int,LSValue*>* LSMap<int,LSValue*>::ls_clear() {
 		LSValue::delete_val(it->second);
 	}
 	clear();
-	if (refs == 0) refs = 1;
 	return this;
 }
 template <>
 inline LSMap<int,int>* LSMap<int,int>::ls_clear() {
 	clear();
-	if (refs == 0) refs = 1;
 	return this;
 }
 template <>
 inline LSMap<int,double>* LSMap<int,double>::ls_clear() {
 	clear();
-	if (refs == 0) refs = 1;
 	return this;
 }
 
 template <>
-inline LSMap<LSValue*,LSValue*>* LSMap<LSValue*,LSValue*>::ls_erase(LSValue* key) {
+inline bool LSMap<LSValue*,LSValue*>::ls_erase(LSValue* key) {
 	auto it = find(key);
 	if (it != end()) {
 		LSValue::delete_val(it->first);
 		LSValue::delete_val(it->second);
 		erase(it);
+		return true;
 	}
-	if (refs == 0) refs = 1;
-	return this;
+	return false;
 }
 template <>
-inline LSMap<LSValue*,int>* LSMap<LSValue*,int>::ls_erase(LSValue* key) {
+inline bool LSMap<LSValue*,int>::ls_erase(LSValue* key) {
 	auto it = find(key);
 	if (it != end()) {
 		LSValue::delete_val(it->first);
 		erase(it);
+		return true;
 	}
-	if (refs == 0) refs = 1;
-	return this;
+	return false;
 }
 template <>
-inline LSMap<LSValue*,double>* LSMap<LSValue*,double>::ls_erase(LSValue* key) {
+inline bool LSMap<LSValue*,double>::ls_erase(LSValue* key) {
 	auto it = find(key);
 	if (it != end()) {
 		LSValue::delete_val(it->first);
 		erase(it);
+		return true;
 	}
-	if (refs == 0) refs = 1;
-	return this;
+	return false;
 }
 template <>
-inline LSMap<int,LSValue*>* LSMap<int,LSValue*>::ls_erase(int key) {
+inline bool LSMap<int,LSValue*>::ls_erase(int key) {
 	auto it = find(key);
 	if (it != end()) {
 		LSValue::delete_val(it->second);
 		erase(it);
+		return true;
 	}
-	if (refs == 0) refs = 1;
-	return this;
+	return false;
 }
 template <>
-inline LSMap<int,int>* LSMap<int,int>::ls_erase(int key) {
-	erase(key);
-	if (refs == 0) refs = 1;
-	return this;
+inline bool LSMap<int,int>::ls_erase(int key) {
+	return erase(key);
 }
 template <>
-inline LSMap<int,double>* LSMap<int,double>::ls_erase(int key) {
-	erase(key);
-	if (refs == 0) refs = 1;
-	return this;
+inline bool LSMap<int,double>::ls_erase(int key) {
+	return erase(key);
 }
 
 
@@ -209,11 +207,9 @@ template <>
 inline LSValue* LSMap<LSValue*,LSValue*>::ls_look(LSValue* key, LSValue* def) {
 	auto it = find(key);
 	if (it != end()) {
-		it->second->refs++;
 		return it->second;
 	}
-	if (def->refs == 0) def->refs = 1;
-	return def;
+	return def->clone();
 }
 template <>
 inline int LSMap<LSValue*,int>::ls_look(LSValue* key, int def) {
@@ -235,11 +231,9 @@ template <>
 inline LSValue* LSMap<int,LSValue*>::ls_look(int key, LSValue* def) {
 	auto it = find(key);
 	if (it != end()) {
-		it->second->refs++;
 		return it->second;
 	}
-	if (def->refs == 0) def->refs = 1;
-	return def;
+	return def->clone();
 }
 template <>
 inline int LSMap<int,int>::ls_look(int key, int def) {

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -118,7 +118,7 @@ void Test::test_arrays() {
 	success("let x = [1, 2, 3, 4] x.chunk()", "[[1], [2], [3], [4]]");
 
 	success("let x = [1, 1, 2, 2, 1] x.unique() x", "[1, 2, 1]");
-	success("let x = [1, 1, 2, 2, 1] x.sort().unique() x", "[1, 2]");
+	success("let x = [1, 1, 2, 2, 1] x.sort() x.unique() x", "[1, 2]");
 	success("let x = ['a', 'a', 'b'] x.unique() x", "['a', 'b']");
 	success("let x = ['a', 'b', 'c'] x.unique() x", "['a', 'b', 'c']");
 	success("let x = ['a', 'a', 'b', 'a', 'a'] x.unique() x", "['a', 'b', 'a']");

--- a/test/function.cpp
+++ b/test/function.cpp
@@ -43,6 +43,7 @@ void Test::test_functions() {
 	success("return 1; 2", "1");
 	success("let f = function(x) { if (x < 10) {return true} return 12 } [f(5), f(20)]", "[true, 12]");
 	//	success("let a = 10 a ~ x -> x ^ 2", "100");
+	success("let f = x -> { let y = { if x == 0 { return 'error' } 1/x } '' + y } [f(-2), f(0), f(2)]", "['-0.5', 'error', '0.5']");
 
 	/*
 	 * Closures

--- a/test/general.cpp
+++ b/test/general.cpp
@@ -16,7 +16,7 @@ void Test::test_general() {
 	header("General");
 	success("", "null");
 	success(" ", "null"); // classic space
-	success(" ", "null"); // unbreakable space
+	success(" ", "null"); // unbreakable space
 	success("	", "null"); // tab
 	success("null", "null");
 	success("()", "null");
@@ -30,6 +30,7 @@ void Test::test_general() {
 	success("{;}", "null");
 	success("return 12", "12");
 	success("return", "null");
+	success("'a' 'b' 'c'", "'c'");
 
 	header("Variables");
 	success("let a = 2 a", "2");

--- a/test/map.cpp
+++ b/test/map.cpp
@@ -6,23 +6,30 @@ void Test::test_map() {
 
 	success("[1 : 1 2 : 2]", "[1 : 1 2 : 2]");
 	success("[1 : 1 2 : '2']", "[1 : 1 2 : '2']");
+	success("['1' : '1' '1' : '2' '1' : '3']", "['1' : '1']");
 
 	success("let x = [1 : 1 1 : 2 1 : 3] x.size()", "1");
 	success("let x = [1 : 1 1 : 2 2 : '3'] x.size()", "2");
 
-	success("let x = [1 : 1] x.insert(2, 2)", "[1 : 1 2 : 2]");
-	success("let x = ['a' : 'a'] x.insert(2, 2)", "[2 : 2 'a' : 'a']");
-	success("let x = [1 : 'a'] x.insert(2, 3)", "[1 : 'a' 2 : 3]");
-	success("let x = ['a' : 1] x.insert(2, 3)", "[2 : 3 'a' : 1]");
+	success("let x = [1 : 1] x.insert(2, 2)", "true");
+	success("let x = ['a' : 'a'] x.insert(2, 2) x", "[2 : 2 'a' : 'a']");
+	success("let x = [1 : 'a'] x.insert(2, 3) x", "[1 : 'a' 2 : 3]");
+	success("let x = ['a' : 1] x.insert(2, 3) x", "[2 : 3 'a' : 1]");
+	success("let x = ['a' : 1] x.insert('a', 3)", "false");
 
 	success("let x = [1 : 1] x.clear()", "[]");
 	success("let x = ['a' : 'a'] x.clear()", "[]");
 
-	success("let x = [1 : 1] x.erase(1)", "[]");
-	success("let x = ['a' : 'a'] x.erase('a')", "[]");
-	success("let x = ['a' : 'a'] x.erase('b')", "['a' : 'a']");
-	success("let x = ['a' : 1] x.erase(3.14)", "['a' : 1]");
+	success("let x = [1 : 1] x.erase(1)", "true");
+	success("let x = ['a' : 'a'] x.erase('a') x", "[]");
+	success("let x = ['a' : 'a'] x.erase('b') x", "['a' : 'a']");
+	success("let x = ['a' : 1] x.erase(3.14) x", "['a' : 1]");
+
+	success("let x = [1 : 1] x.look(1,0)", "1");
+	//success("let x = ['a' : 'a'] x.look('a','b')", "'a'");
+	success("let x = ['a' : 'a'] x.look('b','b')", "'b'");
+	success("let x = ['a' : 1] x.look(3.14,'a')", "'a'");
 
 	success("['a':'b'] == [1:1]", "false");
-	//success("let x = ['a' : 'b'] let y = [1 : 1] x.clear() == y.clear()", "true");
+	success("let x = ['a' : 'b'] let y = [1 : 1] x.clear() == y.clear()", "true");
 }


### PR DESCRIPTION
- replace `analyse(analyser)` by `analyse(analyser, Type::UNKNOWN)`
- construct Array and Map with a move
- dissociate block type and return type

```
function text() {
    let n = {
        if (error) return ''; // return is {string*}
        1 + 2 // type is {int}
    }
    'value = ' + n
}
```
- Block request VOID type to it's instruction except the last one
- ExpressionInstruction delete temporary variable if request type is VOID `'a' 'b' 'c' // 'a' and 'b' will be delete by ExpressionInstruction but 'c' will be returned`
- Into `Program` replaced `Block* body` by `Function* main` to be able to call `enter_function(program->main)`
- `Return` instruction are now well managed. A `Black` that has type `Type::VOID` does not return anything because it contains a `return`

```
>> if 1 return 1 'test'
Program: {
    if 1 {int} {
        return 1 {int*}
    } {void} {?*}
    'test' {string*}
} {string*}
{function () → {?*}}
1

>> if 0 return 1
Program: {
    if 0 {int} {
        return 1 {int*}
    } {void} {?*}
} {?*}
{function () → {?*}}
null

>> if 0 return 1 return 0
Program: {
    if 0 {int} {
        return 1 {int}
    } {void} {?*}
    return 0 {int}
} {void}
{function () → {int}}
0
```
- Optimization : no compilation after a `return` instruction

```
>> return 1 'test'
Program: {
    return 1 {int}
    'test' {string*}
} {void}
{function () → {int}}
```
- If `if.then` block or `if.else` block contains a `return` (=== his type is `Type::VOID`) then the `if` type is the type of the other block

```
>> let x = if 1 { return 1 } else { 3.5 } x
Program: {
    let x = if 1 {int} {
        return 1 {real}
    } {void} else {
        3.5 {real}
    } {real} {real}
    x {real}
} {real}
{function () → {real}}
1
```
- `VM::create_null` -> `VM::get_null` that just create a constant pointer
- remove `refs++` in methods. Add a check at `FunctionCall` for that
- fix leaks in maps
