### PR TITLE
Types

### DIFF
--- a/src/vm/LSValue.cpp
+++ b/src/vm/LSValue.cpp
@@ -18,12 +18,12 @@ extern std::map<LSValue*, LSValue*> objs;
 
 LSValue::LSValue() : refs(0), native(false) {
 	obj_count++;
-//	objs.insert({this, this});
+	objs.insert({this, this});
 }
 
 LSValue::LSValue(const LSValue& other) : refs(0), native(other.native) {
 	obj_count++;
-//	objs.insert({this, this});
+	objs.insert({this, this});
 }
 
 LSValue::~LSValue() {

--- a/src/vm/LSValue.cpp
+++ b/src/vm/LSValue.cpp
@@ -18,12 +18,12 @@ extern std::map<LSValue*, LSValue*> objs;
 
 LSValue::LSValue() : refs(0), native(false) {
 	obj_count++;
-	objs.insert({this, this});
+//	objs.insert({this, this});
 }
 
 LSValue::LSValue(const LSValue& other) : refs(0), native(other.native) {
 	obj_count++;
-	objs.insert({this, this});
+//	objs.insert({this, this});
 }
 
 LSValue::~LSValue() {

--- a/src/vm/Type.hpp
+++ b/src/vm/Type.hpp
@@ -6,12 +6,6 @@
 
 namespace ls {
 
-/*
-enum class RawType {
-	UNKNOWN, NULLL, BOOLEAN, NUMBER, INTEGER, LONG, FLOAT, STRING, OBJECT, ARRAY, FUNCTION, CLASS
-};
-*/
-
 enum class Nature {
 	UNKNOWN, VALUE, POINTER, VOID
 };
@@ -21,14 +15,12 @@ public:
 	virtual const std::string getName() const { return "?"; }
 	virtual const std::string getClass() const { return "?"; }
 	virtual const std::string getJsonName() const { return "?"; }
-	virtual bool derived_from(const BaseRawType*) const { return false; }
 };
 
 class VoidRawType : public BaseRawType {
 public:
 	virtual const std::string getName() const { return "void"; }
 	virtual const std::string getJsonName() const { return "void"; }
-	virtual bool derived_from(const BaseRawType*) const { return true; }
 };
 
 class NullRawType : public BaseRawType {
@@ -36,7 +28,6 @@ public:
 	virtual const std::string getName() const { return "null"; }
 	virtual const std::string getClass() const { return "Null"; }
 	virtual const std::string getJsonName() const { return "null"; }
-	virtual bool derived_from(const BaseRawType*) const { return true; }
 };
 
 class BooleanRawType : public BaseRawType {
@@ -44,7 +35,6 @@ public:
 	virtual const std::string getName() const { return "bool"; }
 	virtual const std::string getClass() const { return "Boolean"; }
 	virtual const std::string getJsonName() const { return "boolean"; }
-	virtual bool derived_from(const BaseRawType*) const { return true; }
 };
 
 class NumberRawType : public BaseRawType {
@@ -52,7 +42,6 @@ public:
 	virtual const std::string getName() const { return "number"; }
 	virtual const std::string getClass() const { return "Number"; }
 	virtual const std::string getJsonName() const { return "number"; }
-	virtual bool derived_from(const BaseRawType*) const { return true; }
 };
 
 class IntegerRawType : public NumberRawType {
@@ -60,8 +49,6 @@ public:
 	virtual const std::string getName() const { return "int"; }
 	virtual const std::string getClass() const { return "Number"; }
 	virtual const std::string getJsonName() const { return "number"; }
-	virtual bool operator > (const NumberRawType*) { return true; }
-	virtual bool derived_from(const NumberRawType*) const { return true; }
 };
 
 class LongRawType : public NumberRawType {
@@ -69,7 +56,6 @@ public:
 	virtual const std::string getName() const { return "long"; }
 	virtual const std::string getClass() const { return "Number"; }
 	virtual const std::string getJsonName() const { return "number"; }
-	virtual bool derived_from(const NumberRawType*) const { return true; }
 };
 
 class FloatRawType : public NumberRawType {
@@ -77,7 +63,6 @@ public:
 	virtual const std::string getName() const { return "real"; }
 	virtual const std::string getClass() const { return "Number"; }
 	virtual const std::string getJsonName() const { return "number"; }
-	virtual bool derived_from(const NumberRawType*) const { return true; }
 };
 
 class StringRawType : public BaseRawType {
@@ -85,7 +70,6 @@ public:
 	virtual const std::string getName() const { return "string"; }
 	virtual const std::string getClass() const { return "String"; }
 	virtual const std::string getJsonName() const { return "string"; }
-	virtual bool derived_from(const BaseRawType*) const { return true; }
 };
 
 class ArrayRawType : public BaseRawType {
@@ -93,7 +77,6 @@ public:
 	virtual const std::string getName() const { return "array"; }
 	virtual const std::string getClass() const { return "Array"; }
 	virtual const std::string getJsonName() const { return "array"; }
-	virtual bool derived_from(const BaseRawType*) const { return true; }
 };
 
 class MapRawType : public BaseRawType {
@@ -101,7 +84,6 @@ public:
 	virtual const std::string getName() const { return "map"; }
 	virtual const std::string getClass() const { return "Map"; }
 	virtual const std::string getJsonName() const { return "map"; }
-	virtual bool derived_from(const BaseRawType*) const { return true; }
 };
 
 class IntervalRawType : public BaseRawType {
@@ -109,7 +91,6 @@ public:
 	virtual const std::string getName() const { return "interval"; }
 	virtual const std::string getClass() const { return "Array"; }
 	virtual const std::string getJsonName() const { return "array"; }
-	virtual bool derived_from(const ArrayRawType*) const { return true; }
 };
 
 class ObjectRawType : public BaseRawType {
@@ -117,7 +98,6 @@ public:
 	virtual const std::string getName() const { return "object"; }
 	virtual const std::string getClass() const { return "Object"; }
 	virtual const std::string getJsonName() const { return "object"; }
-	virtual bool derived_from(const BaseRawType*) const { return true; }
 };
 
 class FunctionRawType : public BaseRawType {
@@ -125,7 +105,6 @@ public:
 	virtual const std::string getName() const { return "function"; }
 	virtual const std::string getClass() const { return "Function"; }
 	virtual const std::string getJsonName() const { return "function"; }
-	virtual bool derived_from(const BaseRawType*) const { return true; }
 };
 
 class ClassRawType : public BaseRawType {
@@ -133,7 +112,6 @@ public:
 	virtual const std::string getName() const { return "class"; }
 	virtual const std::string getClass() const { return "Class"; }
 	virtual const std::string getJsonName() const { return "class"; }
-	virtual bool derived_from(const BaseRawType*) const { return true; }
 };
 
 class RawType {
@@ -167,12 +145,9 @@ public:
 	std::vector<Type> arguments_types;
 
 	Type();
-	Type(const Type& type);
-	Type(const BaseRawType* raw_type, Nature nature);
-	Type(const BaseRawType* raw_type, Nature nature, bool native);
-	Type(const BaseRawType* raw_type, Nature nature, const Type& elements_type);
-	Type(const BaseRawType* raw_type, Nature nature, const Type& elements_type, bool native);
-	Type(const BaseRawType* raw_type, Nature nature, const std::vector<Type>& element_types);
+	Type(const BaseRawType* raw_type, Nature nature, bool native = false);
+	Type(const BaseRawType* raw_type, Nature nature, const Type& elements_type, bool native = false);
+	Type(const BaseRawType* raw_type, Nature nature, const std::vector<Type>& element_types, bool native = false);
 
 	bool must_manage_memory() const;
 
@@ -180,27 +155,25 @@ public:
 	void setReturnType(Type type);
 
 	void addArgumentType(Type type);
-	void setArgumentType(const unsigned int index, Type type);
-	const Type getArgumentType(const unsigned int index) const;
-	const std::vector<Type> getArgumentTypes() const;
+	void setArgumentType(size_t index, Type type);
+	const Type getArgumentType(size_t index) const;
+	const std::vector<Type>& getArgumentTypes() const;
+
 	const Type getElementType(size_t i = 0) const;
 	void setElementType(Type);
-	bool isHomogeneous() const;
-
-	std::string get_class_name() const;
 
 	bool will_take(const int i, const Type& arg_type);
 	bool will_take_element(const Type& arg_type);
 	Type mix(const Type& x) const;
-	bool compatible(const Type& type) const;
-
-	bool operator == (const Type&) const;
-	bool operator != (const Type&) const;
 
 	void toJson(std::ostream&) const;
 
 	bool isNumber() const;
-	bool derived_from(const Type& type);
+
+	bool operator ==(const Type& type) const;
+	inline bool operator !=(const Type& type) const { return !(*this == type); }
+
+	bool compatible(const Type& type) const;
 
 	/*
 	 * Static part
@@ -238,12 +211,12 @@ public:
 	static const Type FUNCTION_P;
 	static const Type CLASS;
 
-	static std::string get_nature_name(const Nature& nature);
-	static std::string get_nature_symbol(const Nature& nature);
 	static bool list_compatible(const std::vector<Type>& expected, const std::vector<Type>& actual);
 	static bool list_more_specific(const std::vector<Type>& old, const std::vector<Type>& neww);
 	static bool more_specific(const Type& old, const Type& neww);
 	static Type get_compatible_type(const Type& t1, const Type& t2);
+	static std::string get_nature_name(const Nature& nature);
+	static std::string get_nature_symbol(const Nature& nature);
 };
 
 std::ostream& operator << (std::ostream&, const Type&);

--- a/src/vm/value/LSClass.cpp
+++ b/src/vm/value/LSClass.cpp
@@ -60,21 +60,18 @@ Method* LSClass::getMethod(std::string& name, Type obj_type, vector<Type>& args)
 	try {
 		vector<Method>& impl = methods.at(name);
 		Method* best = nullptr;
-		for (Method& m : impl) {
-//			cout << "Test impl : " << m.type << endl;
 
+		for (Method& m : impl) {
 			if (m.obj_type.compatible(obj_type) and Type::list_compatible(m.type.arguments_types, args)) {
-//				cout << "Impl good : " << m.type << endl;
 				if (best == nullptr or
 					Type::list_more_specific(best->type.arguments_types, m.type.arguments_types) or
-					Type::more_specific(m.obj_type, best->obj_type)) {
+					Type::more_specific(best->obj_type, m.obj_type) /* old, new */) {
 					best = &m;
-//					cout << "best : " << m.type << endl;
 				}
 			}
 		}
 		return best;
-	} catch (exception& e) {
+	} catch (exception&) {
 		return nullptr;
 	}
 }
@@ -83,19 +80,16 @@ StaticMethod* LSClass::getStaticMethod(std::string& name, vector<Type>& args) {
 	try {
 		vector<StaticMethod>& impl = static_methods.at(name);
 		StaticMethod* best = nullptr;
+
 		for (auto& m : impl) {
-//			cout << "Test impl : " << m.type << endl;
 			if (Type::list_compatible(m.type.arguments_types, args)) {
-//				cout << "Impl good : " << m.type << endl;
 				if (best == nullptr or Type::list_more_specific(best->type.arguments_types, m.type.arguments_types)) {
-//					cout << "Better" << endl;
 					best = &m;
 				}
 			}
 		}
-//		cout << "BEST : " << best->type << endl;
 		return best;
-	} catch (exception& e) {
+	} catch (exception&) {
 		return nullptr;
 	}
 }


### PR DESCRIPTION
- remove useless constructors
- use default copy constructor
- simplify implementation of `operator ==`
- make arguments of `more_specific` and `list_more_specific` coherent i.e. always `(old, new)`
- remove `derived_from` that didn't worked
- symmetrize `get_compatible_type` arguments i.e. `(t1, t2) <=> (t2,t1)` 
- remove debug comments
- sort method implementations
