### PR TITLE
Miscellaneous

### DIFF
--- a/src/compiler/instruction/Foreach.cpp
+++ b/src/compiler/instruction/Foreach.cpp
@@ -325,7 +325,7 @@ jit_value_t Foreach::compile(Compiler& c) const {
 
 		// Dynamic selector
 		jit_type_t args_types_sel[1] = {JIT_POINTER};
-		jit_type_t sig_sel = jit_type_create_signature(jit_abi_cdecl, jit_type_int, args_types_sel, 1, 0);
+		jit_type_t sig_sel = jit_type_create_signature(jit_abi_cdecl, JIT_INTEGER, args_types_sel, 1, 0);
 		jit_value_t s = jit_insn_call_native(c.F, "selector", (void*) fun_selector, sig_sel, &a, 1, JIT_CALL_NOTHROW);
 
 		// Goto begin
@@ -440,7 +440,7 @@ void Foreach::compile_foreach(Compiler&c, jit_value_t a,
 
 	// Condition to continue
 	jit_type_t args_types_cond[2] = {JIT_POINTER, JIT_POINTER};
-	jit_type_t sig_cond = jit_type_create_signature(jit_abi_cdecl, jit_type_sys_bool, args_types_cond, 2, 0);
+	jit_type_t sig_cond = jit_type_create_signature(jit_abi_cdecl, JIT_BOOLEAN, args_types_cond, 2, 0);
 	jit_value_t args_cond[2] = { a, it };
 	jit_value_t cond = jit_insn_call_native(c.F, "cond", (void*) fun_condition, sig_cond, args_cond, 2, JIT_CALL_NOTHROW);
 	jit_insn_branch_if_not(c.F, cond, label_end);
@@ -494,7 +494,7 @@ void Foreach::compile_foreach_noblock(Compiler& c, jit_value_t a,
 
 	// Condition to continue
 	jit_type_t args_types_cond[2] = {JIT_POINTER, JIT_POINTER};
-	jit_type_t sig_cond = jit_type_create_signature(jit_abi_cdecl, jit_type_sys_bool, args_types_cond, 2, 0);
+	jit_type_t sig_cond = jit_type_create_signature(jit_abi_cdecl, JIT_BOOLEAN, args_types_cond, 2, 0);
 	jit_value_t args_cond[2] = { a, it };
 	jit_value_t cond = jit_insn_call_native(c.F, "cond", (void*) fun_condition, sig_cond, args_cond, 2, JIT_CALL_NOTHROW);
 	jit_insn_branch_if_not(c.F, cond, label_end);

--- a/src/compiler/instruction/VariableDeclaration.cpp
+++ b/src/compiler/instruction/VariableDeclaration.cpp
@@ -51,10 +51,14 @@ void VariableDeclaration::analyse(SemanticAnalyser* analyser, const Type&) {
 		Token* var = variables[i];
 		Value* value = nullptr;
 
+		// let x = (... x not defined here ...)
+		if (i < expressions.size()) {
+			expressions[i]->analyse(analyser, Type::UNKNOWN);
+		}
+
 		SemanticVar* v = analyser->add_var(var, Type::UNKNOWN, value, this);
 
 		if (i < expressions.size()) {
-			expressions[i]->analyse(analyser, Type::UNKNOWN);
 			v->type = expressions[i]->type;
 			v->value = expressions[i];
 		}

--- a/src/compiler/semantic/SemanticAnalyser.cpp
+++ b/src/compiler/semantic/SemanticAnalyser.cpp
@@ -31,10 +31,10 @@ SemanticAnalyser::SemanticAnalyser() {
 
 SemanticAnalyser::~SemanticAnalyser() {}
 
-void SemanticVar::will_take(SemanticAnalyser* analyser, unsigned pos, const Type& type) {
+void SemanticVar::will_take(SemanticAnalyser* analyser, const std::vector<Type>& args_type) {
 	if (value != nullptr) {
-		value->will_take(analyser, pos, type);
-		this->type.will_take(pos, type);
+		value->will_take(analyser, args_type);
+		type.will_take(args_type);
 	}
 }
 

--- a/src/compiler/semantic/SemanticAnalyser.hpp
+++ b/src/compiler/semantic/SemanticAnalyser.hpp
@@ -39,7 +39,7 @@ public:
 		VariableDeclaration* vd, Function* function) :
 		name(name), scope(scope), type(type), index(index), value(value), vd(vd), function(function) {}
 
-	void will_take(SemanticAnalyser*, unsigned, const Type&);
+	void will_take(SemanticAnalyser*, const std::vector<Type>& args_type);
 	void will_take_element(SemanticAnalyser*, const Type&);
 	void must_be_pointer(SemanticAnalyser*);
 };

--- a/src/compiler/value/Array.cpp
+++ b/src/compiler/value/Array.cpp
@@ -92,7 +92,7 @@ void Array::analyse(SemanticAnalyser* analyser, const Type&) {
 	}
 }
 
-void Array::elements_will_take(SemanticAnalyser* analyser, const unsigned pos, const Type& type, int level) {
+void Array::elements_will_take(SemanticAnalyser* analyser, const vector<Type>& args_type, int level) {
 
 //	cout << "Array::elements_will_take " << type << " at " << pos << endl;
 
@@ -100,9 +100,9 @@ void Array::elements_will_take(SemanticAnalyser* analyser, const unsigned pos, c
 
 		Array* arr = dynamic_cast<Array*>(expressions[i]);
 		if (arr != nullptr && level > 0) {
-			arr->elements_will_take(analyser, pos, type, level - 1);
+			arr->elements_will_take(analyser, args_type, level - 1);
 		} else {
-			expressions[i]->will_take(analyser, pos, type);
+			expressions[i]->will_take(analyser, args_type);
 		}
 	}
 

--- a/src/compiler/value/Array.cpp
+++ b/src/compiler/value/Array.cpp
@@ -190,7 +190,7 @@ jit_value_t Array::compile(Compiler& c) const {
 	jit_type_t elem_type = type.getElementType() == Type::INTEGER ? JIT_INTEGER :
 			type.getElementType() == Type::FLOAT ? JIT_FLOAT : JIT_POINTER;
 
-	jit_value_t s = JIT_CREATE_CONST(c.F, ls_jit_integer, expressions.size());
+	jit_value_t s = JIT_CREATE_CONST(c.F, JIT_INTEGER, expressions.size());
 	jit_value_t args_v[] = {s};
 	jit_value_t array = jit_insn_call_native(c.F, "new", create, sig, args_v, 1, JIT_CALL_NOTHROW);
 
@@ -199,7 +199,7 @@ jit_value_t Array::compile(Compiler& c) const {
 		jit_value_t v = val->compile(c);
 
 		jit_type_t args[2] = {JIT_POINTER, elem_type};
-		jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_void, args, 2, 0);
+		jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_VOID, args, 2, 0);
 		jit_value_t args_v[] = {array, v};
 		jit_insn_call_native(c.F, "push", push, sig, args_v, 2, JIT_CALL_NOTHROW);
 	}

--- a/src/compiler/value/Array.hpp
+++ b/src/compiler/value/Array.hpp
@@ -21,7 +21,7 @@ public:
 	virtual unsigned line() const override;
 
 	virtual void analyse(SemanticAnalyser*, const Type&) override;
-	void elements_will_take(SemanticAnalyser*, const unsigned, const Type&, int level);
+	void elements_will_take(SemanticAnalyser*, const std::vector<Type>& args_type, int level);
 
 	virtual jit_value_t compile(Compiler&) const override;
 };

--- a/src/compiler/value/ArrayAccess.cpp
+++ b/src/compiler/value/ArrayAccess.cpp
@@ -97,17 +97,17 @@ void ArrayAccess::analyse(SemanticAnalyser* analyser, const Type& req_type) {
 //	cout << "array access " << type << endl;
 }
 
-bool ArrayAccess::will_take(SemanticAnalyser* analyser, const unsigned pos, const Type arg_type) {
+bool ArrayAccess::will_take(SemanticAnalyser* analyser, const std::vector<Type>& args_type) {
 
 //	cout << "ArrayAccess::will_take " << arg_type << " at " << pos << endl;
 
-	type.will_take(pos, arg_type);
+	type.will_take(args_type);
 
 	if (Array* arr = dynamic_cast<Array*>(array)) {
-		arr->elements_will_take(analyser, pos, arg_type, 1);
+		arr->elements_will_take(analyser, args_type, 1);
 	}
 	if (ArrayAccess* arr = dynamic_cast<ArrayAccess*>(array)) {
-		arr->array_access_will_take(analyser, pos, arg_type, 1);
+		arr->array_access_will_take(analyser, args_type, 1);
 	}
 
 	type = array->type.getElementType();
@@ -115,15 +115,15 @@ bool ArrayAccess::will_take(SemanticAnalyser* analyser, const unsigned pos, cons
 	return false;
 }
 
-bool ArrayAccess::array_access_will_take(SemanticAnalyser* analyser, const unsigned pos, const Type arg_type, int level) {
+bool ArrayAccess::array_access_will_take(SemanticAnalyser* analyser, const vector<Type>& args_type, int level) {
 
-	type.will_take(pos, arg_type);
+	type.will_take(args_type);
 
 	if (Array* arr = dynamic_cast<Array*>(array)) {
-		arr->elements_will_take(analyser, pos, arg_type, level);
+		arr->elements_will_take(analyser, args_type, level);
 	}
 	if (ArrayAccess* arr = dynamic_cast<ArrayAccess*>(array)) {
-		arr->array_access_will_take(analyser, pos, arg_type, level + 1);
+		arr->array_access_will_take(analyser, args_type, level + 1);
 	}
 
 	type = array->type.getElementType();

--- a/src/compiler/value/ArrayAccess.cpp
+++ b/src/compiler/value/ArrayAccess.cpp
@@ -169,8 +169,8 @@ jit_value_t ArrayAccess::compile(Compiler& c) const {
 
 		if (array->type == Type::INTERVAL) {
 
-			jit_type_t args_types[2] = {ls_jit_pointer, ls_jit_integer};
-			jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, ls_jit_integer, args_types, 2, 0);
+			jit_type_t args_types[2] = {JIT_POINTER, JIT_INTEGER};
+			jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_INTEGER, args_types, 2, 0);
 
 			jit_value_t k = key->compile(c);
 

--- a/src/compiler/value/ArrayAccess.hpp
+++ b/src/compiler/value/ArrayAccess.hpp
@@ -21,8 +21,8 @@ public:
 	virtual unsigned line() const override;
 
 	virtual void analyse(SemanticAnalyser*, const Type&) override;
-	virtual bool will_take(SemanticAnalyser* analyser, const unsigned, const Type);
-	bool array_access_will_take(SemanticAnalyser* analyser, const unsigned, const Type, int level);
+	virtual bool will_take(SemanticAnalyser* analyser, const std::vector<Type>& args_type) override;
+	bool array_access_will_take(SemanticAnalyser* analyser, const std::vector<Type>& args_type, int level);
 	virtual void change_type(SemanticAnalyser*, const Type&) override;
 
 	virtual jit_value_t compile(Compiler&) const override;

--- a/src/compiler/value/Block.cpp
+++ b/src/compiler/value/Block.cpp
@@ -21,21 +21,13 @@ Block::~Block() {
 
 void Block::print(ostream& os, int indent, bool debug) const {
 	os << "{";
-	if (instructions.size() > 1) {
+	os << endl;
+	for (Instruction* instruction : instructions) {
+		os << tabs(indent + 1);
+		instruction->print(os, indent + 1, debug);
 		os << endl;
-		for (Instruction* instruction : instructions) {
-			os << tabs(indent + 1);
-			instruction->print(os, indent + 1, debug);
-			os << endl;
-		}
-		os << tabs(indent) << "}";
-	} else {
-		for (Instruction* instruction : instructions) {
-			os << " ";
-			instruction->print(os, indent + 1, debug);
-		}
-		os << " }";
 	}
+	os << tabs(indent) << "}";
 	if (debug) {
 		os << " " << type;
 	}

--- a/src/compiler/value/Expression.cpp
+++ b/src/compiler/value/Expression.cpp
@@ -217,7 +217,7 @@ void Expression::analyse(SemanticAnalyser* analyser, const Type& req_type) {
 
 	// [1, 2, 3] ~~ x -> x ^ 2
 	if (op->type == TokenType::TILDE_TILDE) {
-		v2->will_take(analyser, 0, v1->type.getElementType());
+		v2->will_take(analyser, { v1->type.getElementType() });
 		type = Type::ARRAY;
 		type.setElementType(v2->type.getReturnType());
 	}

--- a/src/compiler/value/Expression.cpp
+++ b/src/compiler/value/Expression.cpp
@@ -893,11 +893,11 @@ jit_value_t Expression::compile(Compiler& c) const {
 
 			jit_label_t label_end = jit_label_undefined;
 			jit_label_t label_else = jit_label_undefined;
-			jit_value_t v = jit_value_create(c.F, ls_jit_pointer);
+			jit_value_t v = jit_value_create(c.F, JIT_POINTER);
 
-			jit_type_t args_types[2] = {ls_jit_pointer};
+			jit_type_t args_types[2] = {JIT_POINTER};
 			jit_value_t x = v1->compile(c);
-			jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, ls_jit_integer, args_types, 1, 0);
+			jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_INTEGER, args_types, 1, 0);
 			jit_value_t r = jit_insn_call_native(c.F, "is_null", (void*) jit_is_null, sig, &x, 1, JIT_CALL_NOTHROW);
 
 			jit_insn_branch_if(c.F, r, &label_else);

--- a/src/compiler/value/Function.hpp
+++ b/src/compiler/value/Function.hpp
@@ -21,7 +21,7 @@ public:
 	std::vector<Value*> defaultValues;
 	std::vector<SemanticVar*> captures;
 	Block* body;
-	int pos;
+	bool body_analysed;
 	std::map<std::string, SemanticVar*> vars;
 	bool function_added;
 	Function* parent;
@@ -37,7 +37,7 @@ public:
 
 	virtual void analyse(SemanticAnalyser*, const Type&) override;
 
-	bool will_take(SemanticAnalyser*, const unsigned pos, const Type) override;
+	bool will_take(SemanticAnalyser*, const std::vector<Type>& args_type) override;
 
 	void must_return(SemanticAnalyser*, const Type&) override;
 

--- a/src/compiler/value/FunctionCall.cpp
+++ b/src/compiler/value/FunctionCall.cpp
@@ -305,7 +305,7 @@ void FunctionCall::analyse(SemanticAnalyser* analyser, const Type& req_type) {
 	}
 
 	// The function is a variable
-	if (vv and vv->var->value != nullptr) {
+	if (vv and vv->var and vv->var->value) {
 		a = 0;
 		for (Value* arg : arguments) {
 			vv->var->will_take(analyser, a++, arg->type);

--- a/src/compiler/value/Map.cpp
+++ b/src/compiler/value/Map.cpp
@@ -170,7 +170,7 @@ jit_value_t Map::compile(Compiler &c) const {
 		jit_value_t v = values[i]->compile(c);
 
 		jit_type_t args[3] = {JIT_POINTER, key_type, value_type};
-		jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_void, args, 3, 0);
+		jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_VOID, args, 3, 0);
 		jit_value_t args_v[] = {map, k, v};
 		jit_insn_call_native(c.F, "insert", (void*) insert, sig, args_v, 3, JIT_CALL_NOTHROW); ops += std::log2(i + 1);
 

--- a/src/compiler/value/Match.cpp
+++ b/src/compiler/value/Match.cpp
@@ -215,7 +215,7 @@ bool jit_greater_equal_(LSValue* x, LSValue* y) {
 jit_value_t Match::Pattern::match(Compiler &c, jit_value_t v) const {
 
 	jit_type_t args_types[2] = {JIT_POINTER, JIT_POINTER};
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_sys_bool, args_types, 2, 0);
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_BOOLEAN, args_types, 2, 0);
 
 	if (interval) {
 		jit_value_t ge = nullptr;

--- a/src/compiler/value/Number.cpp
+++ b/src/compiler/value/Number.cpp
@@ -45,13 +45,13 @@ jit_value_t Number::compile(Compiler& c) const {
 
 	if (type.nature == Nature::POINTER) {
 
-		jit_value_t val = JIT_CREATE_CONST_FLOAT(c.F, ls_jit_real, value);
+		jit_value_t val = JIT_CREATE_CONST_FLOAT(c.F, JIT_FLOAT, value);
 		return VM::value_to_pointer(c.F, val, Type::FLOAT);
 
 	} else {
 
 		bool isfloat = type.raw_type == RawType::FLOAT;
-		jit_type_t type = isfloat ? ls_jit_real : ls_jit_integer;
+		jit_type_t type = isfloat ? JIT_FLOAT : JIT_INTEGER;
 
 		if (isfloat) {
 			return JIT_CREATE_CONST_FLOAT(c.F, type, value);

--- a/src/compiler/value/Object.cpp
+++ b/src/compiler/value/Object.cpp
@@ -56,7 +56,7 @@ jit_value_t Object::compile(Compiler& c) const {
 	jit_value_t object = VM::create_object(c.F);
 
 	jit_type_t args[3] = {JIT_POINTER, JIT_POINTER, JIT_POINTER};
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_void, args, 3, 0);
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_VOID, args, 3, 0);
 
 	for (unsigned i = 0; i < keys.size(); ++i) {
 		jit_value_t k = JIT_CREATE_CONST_POINTER(c.F, &keys.at(i)->token->content);

--- a/src/compiler/value/Value.cpp
+++ b/src/compiler/value/Value.cpp
@@ -10,8 +10,8 @@ Value::Value() {
 
 Value::~Value() {}
 
-bool Value::will_take(SemanticAnalyser*, const unsigned i, const Type arg_type) {
-	return type.will_take(i, arg_type);
+bool Value::will_take(SemanticAnalyser*, const std::vector<Type>& args_type) {
+	return type.will_take(args_type);
 }
 
 bool Value::will_take_element(SemanticAnalyser*, const Type arg_type) {

--- a/src/compiler/value/Value.hpp
+++ b/src/compiler/value/Value.hpp
@@ -28,7 +28,7 @@ public:
 
 	virtual unsigned line() const = 0;
 
-	virtual bool will_take(SemanticAnalyser*, const unsigned, const Type);
+	virtual bool will_take(SemanticAnalyser*, const std::vector<Type>& args_type);
 	virtual bool will_take_element(SemanticAnalyser*, const Type);
 	virtual bool must_be_pointer(SemanticAnalyser*);
 	virtual void must_return(SemanticAnalyser*, const Type&);

--- a/src/compiler/value/VariableValue.cpp
+++ b/src/compiler/value/VariableValue.cpp
@@ -53,13 +53,15 @@ void VariableValue::analyse(SemanticAnalyser* analyser, const Type& req_type) {
 //		cout << t.first << " : " << t.second << endl;
 }
 
-bool VariableValue::will_take(SemanticAnalyser* analyser, unsigned pos, const Type type) {
+bool VariableValue::will_take(SemanticAnalyser* analyser, const vector<Type>& args_type) {
 
+	bool changed = false;
 	if (var != nullptr and var->value != nullptr) {
-		var->value->will_take(analyser, pos, type);
-		this->type = var->value->type;
+		changed = var->value->will_take(analyser, args_type);
+		type = var->value->type;
+
 	}
-	return false;
+	return changed;
 }
 
 void VariableValue::must_return(SemanticAnalyser* analyser, const Type& ret_type) {

--- a/src/compiler/value/VariableValue.hpp
+++ b/src/compiler/value/VariableValue.hpp
@@ -24,7 +24,7 @@ public:
 	virtual unsigned line() const override;
 
 	virtual void analyse(SemanticAnalyser*, const Type&) override;
-	virtual bool will_take(SemanticAnalyser* analyser, unsigned pos, const Type type) override;
+	virtual bool will_take(SemanticAnalyser* analyser, const std::vector<Type>& args_type) override;
 	void must_return(SemanticAnalyser* analyser, const Type& type) override;
 	virtual void change_type(SemanticAnalyser*, const Type&) override;
 

--- a/src/vm/LSValue.cpp
+++ b/src/vm/LSValue.cpp
@@ -18,12 +18,12 @@ extern std::map<LSValue*, LSValue*> objs;
 
 LSValue::LSValue() : refs(0), native(false) {
 	obj_count++;
-	objs.insert({this, this});
+//	objs.insert({this, this});
 }
 
 LSValue::LSValue(const LSValue& other) : refs(0), native(other.native) {
 	obj_count++;
-	objs.insert({this, this});
+//	objs.insert({this, this});
 }
 
 LSValue::~LSValue() {

--- a/src/vm/Program.cpp
+++ b/src/vm/Program.cpp
@@ -150,7 +150,7 @@ void Program::compile_jit(Compiler& c, Context& context, bool toplevel) {
 		jit_value_t array = jit_insn_call_native(F, "new", (void*) &Program_create_array, array_sig, {}, 0, JIT_CALL_NOTHROW);
 
 		jit_type_t push_args_types[2] = {JIT_POINTER, JIT_POINTER};
-		jit_type_t push_sig_pointer = jit_type_create_signature(jit_abi_cdecl, jit_type_void, push_args_types, 2, 0);
+		jit_type_t push_sig_pointer = jit_type_create_signature(jit_abi_cdecl, JIT_VOID, push_args_types, 2, 0);
 
 		jit_value_t push_args[2] = {array, res};
 		jit_insn_call_native(F, "push", (void*) &Program_push_pointer, push_sig_pointer, push_args, 2, 0);
@@ -188,19 +188,19 @@ void Program::compile_jit(Compiler& c, Context& context, bool toplevel) {
 //				cout << "save value" << endl;
 				if (type.raw_type == RawType::NULLL) {
 					jit_type_t push_args_types[2] = {JIT_POINTER, JIT_INTEGER};
-					jit_type_t push_sig = jit_type_create_signature(jit_abi_cdecl, jit_type_void, push_args_types, 2, 0);
+					jit_type_t push_sig = jit_type_create_signature(jit_abi_cdecl, JIT_VOID, push_args_types, 2, 0);
 					jit_insn_call_native(F, "push", (void*) &Program_push_null, push_sig, var_args, 2, JIT_CALL_NOTHROW);
 				} else if (type.raw_type == RawType::BOOLEAN) {
 					jit_type_t push_args_types[2] = {JIT_POINTER, JIT_INTEGER};
-					jit_type_t push_sig = jit_type_create_signature(jit_abi_cdecl, jit_type_void, push_args_types, 2, 0);
+					jit_type_t push_sig = jit_type_create_signature(jit_abi_cdecl, JIT_VOID, push_args_types, 2, 0);
 					jit_insn_call_native(F, "push", (void*) &Program_push_boolean, push_sig, var_args, 2, JIT_CALL_NOTHROW);
 				} else if (type.raw_type == RawType::INTEGER) {
 					jit_type_t push_args_types[2] = {JIT_POINTER, JIT_INTEGER};
-					jit_type_t push_sig = jit_type_create_signature(jit_abi_cdecl, jit_type_void, push_args_types, 2, 0);
+					jit_type_t push_sig = jit_type_create_signature(jit_abi_cdecl, JIT_VOID, push_args_types, 2, 0);
 					jit_insn_call_native(F, "push", (void*) &Program_push_integer, push_sig, var_args, 2, JIT_CALL_NOTHROW);
 				} else if (type.raw_type == RawType::FLOAT) {
 					jit_type_t args_float[2] = {JIT_POINTER, JIT_FLOAT};
-					jit_type_t sig_push_float = jit_type_create_signature(jit_abi_cdecl, jit_type_void, args_float, 2, 0);
+					jit_type_t sig_push_float = jit_type_create_signature(jit_abi_cdecl, JIT_VOID, args_float, 2, 0);
 					jit_insn_call_native(F, "push", (void*) &Program_push_float, sig_push_float, var_args, 2, JIT_CALL_NOTHROW);
 				} else if (type.raw_type == RawType::FUNCTION) {
 					jit_insn_call_native(F, "push", (void*) &Program_push_function, push_sig_pointer, var_args, 2, JIT_CALL_NOTHROW);

--- a/src/vm/Type.cpp
+++ b/src/vm/Type.cpp
@@ -144,34 +144,30 @@ void Type::setElementType(Type type) {
 	}
 }
 
-/*
- *
- */
-bool Type::will_take(const int i, const Type& arg_type) {
+bool Type::will_take(const vector<Type>& args_type) {
 
-//	cout << "before will_take: " << *this << endl;
-//	cout << "will_take " << arg_type << endl;
+	bool changed = false;
 
-	Type current_type = getArgumentType(i);
+	for (size_t i = 0; i < args_type.size(); ++i) {
+		Type current_type = getArgumentType(i);
 
-	/*
-	if (current_type.nature == Nature::MIXED) {
-		return; // No change, it is still mixed
-	}
-	*/
+		/*
+		if (current_type.nature == Nature::MIXED) {
+			return; // No change, it is still mixed
+		}
+		*/
 
-	if (current_type.nature == Nature::UNKNOWN) {
-		setArgumentType(i, arg_type);
-		return true;
-	} else {
-		if (current_type.nature == Nature::VALUE and arg_type.nature == Nature::POINTER) {
-			setArgumentType(i, Type(RawType::UNKNOWN, Nature::POINTER));
-			return true;
+		if (current_type.nature == Nature::UNKNOWN) {
+			setArgumentType(i, args_type[i]);
+			changed = true;
+		} else {
+			if (current_type.nature == Nature::VALUE and args_type[i].nature == Nature::POINTER) {
+				setArgumentType(i, Type(RawType::UNKNOWN, Nature::POINTER));
+				changed = true;
+			}
 		}
 	}
-
-//	cout << "after will_take: " << *this << endl;
-	return false;
+	return changed;
 }
 
 bool Type::will_take_element(const Type& element_type) {

--- a/src/vm/Type.hpp
+++ b/src/vm/Type.hpp
@@ -162,7 +162,7 @@ public:
 	const Type getElementType(size_t i = 0) const;
 	void setElementType(Type);
 
-	bool will_take(const int i, const Type& arg_type);
+	bool will_take(const std::vector<Type>& args_type);
 	bool will_take_element(const Type& arg_type);
 	Type mix(const Type& x) const;
 

--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -80,6 +80,11 @@ string VM::execute(const std::string code, std::string ctx, ExecMode mode) {
 	SemanticAnalyser sem;
 	sem.analyse(program, &context, modules);
 
+	/*
+	 * Debug
+	 */
+	cout << "Program: "; program->print(cout, true);
+
 	if (sem.errors.size()) {
 
 		if (mode == ExecMode::COMMAND_JSON) {
@@ -95,10 +100,6 @@ string VM::execute(const std::string code, std::string ctx, ExecMode mode) {
 		return ctx;
 	}
 
-	/*
-	 * Debug
-	 */
-//	cout << "Program: "; program->print(cout, true);
 
 	// Compilation
 	internals.clear();

--- a/src/vm/VM.cpp
+++ b/src/vm/VM.cpp
@@ -216,18 +216,18 @@ string VM::execute(const std::string code, std::string ctx, ExecMode mode) {
 
 jit_type_t VM::get_jit_type(const Type& type) {
 	if (type.nature == Nature::POINTER) {
-		return ls_jit_pointer;
+		return JIT_POINTER;
 	}
 	if (type.raw_type == RawType::INTEGER || type.raw_type == RawType::BOOLEAN) {
-		return ls_jit_integer;
+		return JIT_INTEGER;
 	}
 	if (type.raw_type == RawType::LONG or type.raw_type == RawType::FUNCTION) {
-		return ls_jit_long;
+		return JIT_INTEGER_LONG;
 	}
 	if (type.raw_type == RawType::FLOAT) {
-		return ls_jit_real;
+		return JIT_FLOAT;
 	}
-	return ls_jit_integer;
+	return JIT_INTEGER;
 }
 
 LSValue* create_null_object(int) {
@@ -310,8 +310,8 @@ bool VM::get_number(jit_function_t F, jit_value_t val) {
 	// x & (1 << 31) == 0
 
 	jit_value_t is_int = jit_insn_eq(F,
-		jit_insn_and(F, val, jit_value_create_nint_constant(F, jit_type_int, 2147483648)),
-		jit_value_create_nint_constant(F, jit_type_int, 0)
+		jit_insn_and(F, val, jit_value_create_nint_constant(F, JIT_INTEGER, 2147483648)),
+		jit_value_create_nint_constant(F, JIT_INTEGER, 0)
 	);
 
 	jit_value_t res;
@@ -337,20 +337,20 @@ void push_array_pointer(LSArray<LSValue*>* array, LSValue* value) {
 jit_value_t VM::new_array(jit_function_t F) {
 	jit_type_t args_t[0] = {};
 	jit_value_t args[0] = {};
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_int, args_t, 0, 0);
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_INTEGER, args_t, 0, 0);
 	return jit_insn_call_native(F, "new", (void*) new_array, sig, args, 0, JIT_CALL_NOTHROW);
 }
 
 void VM::push_array_value(jit_function_t F, jit_value_t array, jit_value_t value) {
 	jit_type_t args[2] = {JIT_INTEGER, JIT_INTEGER};
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_void, args, 2, 0);
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_VOID, args, 2, 0);
 	jit_value_t args_v[] = {array, value};
 	jit_insn_call_native(F, "push", (void*) push_array_value, sig, args_v, 2, JIT_CALL_NOTHROW);
 }
 
 void VM::push_array_pointer(jit_function_t F, jit_value_t array, jit_value_t value) {
 	jit_type_t args[2] = {JIT_INTEGER, JIT_INTEGER};
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_void, args, 2, 0);
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_VOID, args, 2, 0);
 	jit_value_t args_v[] = {array, value};
 	jit_insn_call_native(F, "push", (void*) push_array_pointer, sig, args_v, 2, JIT_CALL_NOTHROW);
 }
@@ -371,7 +371,7 @@ void VM_inc_refs(LSValue* val) {
 
 void VM::inc_refs(jit_function_t F, jit_value_t obj) {
 	jit_type_t args[1] = {JIT_POINTER};
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_void, args, 1, 0);
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_VOID, args, 1, 0);
 	jit_insn_call_native(F, "inc_refs", (void*) VM_inc_refs, sig, &obj, 1, JIT_CALL_NOTHROW);
 }
 
@@ -383,7 +383,7 @@ void VM_inc_refs_if_not_temp(LSValue* val) {
 
 void VM::inc_refs_if_not_temp(jit_function_t F, jit_value_t obj) {
 	jit_type_t args[1] = {JIT_POINTER};
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_void, args, 1, 0);
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_VOID, args, 1, 0);
 	jit_insn_call_native(F, "inc_refs_not_temp", (void*) VM_inc_refs_if_not_temp, sig, &obj, 1, JIT_CALL_NOTHROW);
 }
 
@@ -393,13 +393,13 @@ void VM_dec_refs(LSValue* val) {
 
 void VM::dec_refs(jit_function_t F, jit_value_t obj) {
 	jit_type_t args[1] = {JIT_POINTER};
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_void, args, 1, 0);
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_VOID, args, 1, 0);
 	jit_insn_call_native(F, "dec_refs", (void*) VM_dec_refs, sig, &obj, 1, JIT_CALL_NOTHROW);
 }
 
 void VM::delete_obj(jit_function_t F, jit_value_t obj) {
 	jit_type_t args[1] = {JIT_POINTER};
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_void, args, 1, 0);
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_VOID, args, 1, 0);
 	jit_insn_call_native(F, "delete", (void*) &LSValue::delete_val, sig, &obj, 1, JIT_CALL_NOTHROW);
 }
 
@@ -411,7 +411,7 @@ void VM_delete_temporary(LSValue* val) {
 
 void VM::delete_temporary(jit_function_t F, jit_value_t obj) {
 	jit_type_t args[1] = {JIT_POINTER};
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_void, args, 1, 0);
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_VOID, args, 1, 0);
 	jit_insn_call_native(F, "delete_temporary", (void*) VM_delete_temporary, sig, &obj, 1, JIT_CALL_NOTHROW);
 }
 
@@ -438,9 +438,9 @@ void VM::inc_ops(jit_function_t F, int add) {
 
 	// If greater than the limit, throw exception
 //	jit_type_t args[1] = {JIT_INTEGER};
-//	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_void, args, 1, 0);
+//	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_VOID, args, 1, 0);
 //	jit_insn_call_native(F, "throw_exception", (void*) VM_operation_exception, sig, &jit_ops, 1, JIT_CALL_NOTHROW);
-	jit_insn_throw(F, jit_value_create_nint_constant(F, jit_type_int, 12));
+	jit_insn_throw(F, jit_value_create_nint_constant(F, JIT_INTEGER, 12));
 
 	// End
 	jit_insn_label(F, &label_end);
@@ -453,7 +453,7 @@ void VM_print_int(int val) {
 
 void VM::print_int(jit_function_t F, jit_value_t val) {
 	jit_type_t args[1] = {JIT_INTEGER};
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_void, args, 1, 0);
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_VOID, args, 1, 0);
 	jit_insn_call_native(F, "print_int", (void*) VM_print_int, sig, &val, 1, JIT_CALL_NOTHROW);
 }
 
@@ -466,7 +466,7 @@ LSObject* VM_create_object() {
 }
 
 jit_value_t VM::create_object(jit_function_t F) {
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_void_ptr, {}, 0, 0);
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_POINTER, {}, 0, 0);
 	return jit_insn_call_native(F, "create_object", (void*) VM_create_object, sig, {}, 0, JIT_CALL_NOTHROW);
 }
 
@@ -486,7 +486,7 @@ bool VM_is_true(LSValue* val) {
 
 jit_value_t VM::is_true(jit_function_t F, jit_value_t ptr) {
 	jit_type_t args[1] = {JIT_POINTER};
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, jit_type_sys_bool, args, 1, 0);
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_BOOLEAN, args, 1, 0);
 	return jit_insn_call_native(F, "is_true", (void*) VM_is_true, sig, &ptr, 1, JIT_CALL_NOTHROW);
 }
 

--- a/src/vm/VM.hpp
+++ b/src/vm/VM.hpp
@@ -5,17 +5,12 @@
 #include <string>
 #include <jit/jit.h>
 
-#define USE_INTEGERS 1
-
-#define ls_jit_integer jit_type_int
-#define ls_jit_real jit_type_float64
-#define ls_jit_long jit_type_long
-#define ls_jit_pointer jit_type_void_ptr
-
-#define JIT_INTEGER ls_jit_integer
-#define JIT_INTEGER_LONG ls_jit_long
-#define JIT_FLOAT ls_jit_real
-#define JIT_POINTER ls_jit_pointer
+#define JIT_INTEGER			jit_type_sys_int
+#define JIT_INTEGER_LONG	jit_type_sys_long
+#define JIT_FLOAT			jit_type_sys_double
+#define JIT_BOOLEAN			jit_type_sys_bool
+#define JIT_POINTER			jit_type_void_ptr
+#define JIT_VOID			jit_type_void
 
 #define JIT_CREATE_CONST jit_value_create_nint_constant
 #define JIT_CREATE_CONST_LONG jit_value_create_long_constant

--- a/src/vm/standard/NumberSTD.cpp
+++ b/src/vm/standard/NumberSTD.cpp
@@ -77,16 +77,16 @@ NumberSTD::NumberSTD() : Module("Number") {
 }
 
 jit_value_t Number_e(jit_function_t F) {
-	return jit_value_create_float64_constant(F, jit_type_float64, M_E);
+	return JIT_CREATE_CONST_FLOAT(F, JIT_FLOAT, M_E);
 }
 jit_value_t Number_phi(jit_function_t F) {
-	return jit_value_create_float64_constant(F, jit_type_float64, 1.61803398874989484820);
+	return JIT_CREATE_CONST_FLOAT(F, JIT_FLOAT, 1.61803398874989484820);
 }
 jit_value_t Number_pi(jit_function_t F) {
-	return jit_value_create_float64_constant(F, jit_type_float64, 3.14159265358979323846);
+	return JIT_CREATE_CONST_FLOAT(F, JIT_FLOAT, 3.14159265358979323846);
 }
 jit_value_t Number_epsilon(jit_function_t F) {
-	return jit_value_create_float64_constant(F, jit_type_float64, std::numeric_limits<double>::epsilon());
+	return JIT_CREATE_CONST_FLOAT(F, JIT_FLOAT, std::numeric_limits<double>::epsilon());
 }
 
 LSNumber* number_abs(const LSNumber* number) {

--- a/src/vm/standard/SystemSTD.cpp
+++ b/src/vm/standard/SystemSTD.cpp
@@ -11,9 +11,9 @@ SystemSTD::SystemSTD() : Module("System") {
 
 	static_field("operations", Type::INTEGER, (void*) &System_operations);
 
-	static_field("time", Type::LONG, (void*) &System_time);
-	static_field("milliTime", Type::LONG, (void*) &System_millitime);
-	static_field("microTime", Type::LONG, (void*) &System_microtime);
+	static_field("time", Type::FLOAT, (void*) &System_time);
+	static_field("milliTime", Type::FLOAT, (void*) &System_millitime);
+	static_field("microTime", Type::FLOAT, (void*) &System_microtime);
 	static_field("nanoTime", Type::LONG, (void*) &System_nanotime);
 
 	static_method("print", {
@@ -25,22 +25,22 @@ SystemSTD::SystemSTD() : Module("System") {
 	});
 }
 
-long get_sec_time() {
-	return std::chrono::duration_cast<std::chrono::seconds>(
+double get_sec_time() {
+	return std::chrono::duration_cast<std::chrono::nanoseconds>(
 		std::chrono::system_clock::now().time_since_epoch()
-	).count();
+	).count() * 1e-9;
 }
 
-long get_milli_time() {
-	return std::chrono::duration_cast<std::chrono::milliseconds>(
+double get_milli_time() {
+	return std::chrono::duration_cast<std::chrono::nanoseconds>(
 		std::chrono::system_clock::now().time_since_epoch()
-	).count();
+	).count() * 1e-6;
 }
 
-long get_micro_time() {
-	return std::chrono::duration_cast<std::chrono::microseconds>(
+double get_micro_time() {
+	return std::chrono::duration_cast<std::chrono::nanoseconds>(
 		std::chrono::system_clock::now().time_since_epoch()
-	).count();
+	).count() * 1e-3;
 }
 
 long get_nano_time() {
@@ -50,22 +50,22 @@ long get_nano_time() {
 }
 
 jit_value_t System_operations(jit_function_t F) {
-	jit_value_t jit_ops_ptr = jit_value_create_long_constant(F, jit_type_void_ptr, (long int) &VM::operations);
+	jit_value_t jit_ops_ptr = jit_value_create_long_constant(F, JIT_POINTER, (long int) &VM::operations);
 	return jit_insn_load_relative(F, jit_ops_ptr, 0, jit_type_uint);
 }
 
 jit_value_t System_time(jit_function_t F) {
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_INTEGER_LONG, {}, 0, 0);
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_FLOAT, {}, 0, 0);
 	return jit_insn_call_native(F, "sec_time", (void*) get_sec_time, sig, {}, 0, JIT_CALL_NOTHROW);
 }
 
 jit_value_t System_millitime(jit_function_t F) {
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_INTEGER_LONG, {}, 0, 0);
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_FLOAT, {}, 0, 0);
 	return jit_insn_call_native(F, "milli_time", (void*) get_milli_time, sig, {}, 0, JIT_CALL_NOTHROW);
 }
 
 jit_value_t System_microtime(jit_function_t F) {
-	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_INTEGER_LONG, {}, 0, 0);
+	jit_type_t sig = jit_type_create_signature(jit_abi_cdecl, JIT_FLOAT, {}, 0, 0);
 	return jit_insn_call_native(F, "micro_time", (void*) get_micro_time, sig, {}, 0, JIT_CALL_NOTHROW);
 }
 

--- a/test/function.cpp
+++ b/test/function.cpp
@@ -44,6 +44,9 @@ void Test::test_functions() {
 	success("let f = function(x) { if (x < 10) {return true} return 12 } [f(5), f(20)]", "[true, 12]");
 	//	success("let a = 10 a ~ x -> x ^ 2", "100");
 	success("let f = x -> { let y = { if x == 0 { return 'error' } 1/x } '' + y } [f(-2), f(0), f(2)]", "['-0.5', 'error', '0.5']");
+	success("let f = i -> { [1 2 3][i] } f(1)", "2");
+	success("let f = i -> { [1 2 3][i] } 42", "42");
+	success("let f = a,i -> a[i] f([1 2 3], 1)", "2");
 
 	/*
 	 * Closures


### PR DESCRIPTION
- remove `jit_type_*` and replace by `JIT_*` (why need both ?)
- change return type of `System.time` into float. Up to microsecond a `double` can contain the information `log_2(1471332145 * 1E6) = 50.38 < 52` (we will lose a bit of precision the 18 Sep 2112)
- fix `f(3)` `let x = x` crashes
- `will_take` takes a `vector<Type>&` in argument
- fix `let f = i -> { [1 2 3][i] } f(1)`
- fix `let f = a,i -> a[i] f([1 2 3], 1)`
