### PR TITLE
leaks & move

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SRC := $(foreach sdir,$(SRC_DIR),$(wildcard $(sdir)/*.cpp))
 OBJ := $(patsubst %.cpp,build/%.o,$(SRC))
 OBJ_LIB := $(patsubst %.cpp,build/shared/%.o,$(SRC))
 
-FLAGS := -std=c++11 -O3 -g3 -Wall -Wextra -Wno-pmf-conversions
+FLAGS := -std=c++11 -O0 -g -Wall -Wextra -Wno-pmf-conversions
 LIBS := -ljit
 
 .PHONY: test

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -22,9 +22,11 @@ bool param_exec = false;
 bool param_file = false;
 bool param_json = false;
 
+#if DEBUG > 1
 namespace ls {
 	std::map<LSValue*, LSValue*> objs;
 }
+#endif
 
 int main(int argc, char* argv[]) {
 

--- a/src/compiler/Compiler.cpp
+++ b/src/compiler/Compiler.cpp
@@ -39,7 +39,7 @@ void Compiler::delete_variables_block(jit_function_t F, int deepness) {
 			}
 
 			if (it->second.type.must_manage_memory()) {
-				VM::delete_obj(F, it->second.value);
+				VM::delete_ref(F, it->second.value);
 			}
 		}
 	}

--- a/src/compiler/Compiler.cpp
+++ b/src/compiler/Compiler.cpp
@@ -14,6 +14,7 @@ void Compiler::enter_block() {
 	if (!loops_blocks.empty()) {
 		loops_blocks.back()++;
 	}
+	functions_blocks.back()++;
 }
 
 void Compiler::leave_block(jit_function_t F) {
@@ -22,6 +23,7 @@ void Compiler::leave_block(jit_function_t F) {
 	if (!loops_blocks.empty()) {
 		loops_blocks.back()--;
 	}
+	functions_blocks.back()--;
 }
 
 void Compiler::delete_variables_block(jit_function_t F, int deepness) {
@@ -46,13 +48,19 @@ void Compiler::delete_variables_block(jit_function_t F, int deepness) {
 void Compiler::enter_function(jit_function_t F) {
 	variables.push_back(std::map<std::string, CompilerVar> {});
 	functions.push(F);
+	functions_blocks.push_back(0);
 	this->F = F;
 }
 
 void Compiler::leave_function() {
 	variables.pop_back();
 	functions.pop();
+	functions_blocks.pop_back();
 	this->F = functions.top();
+}
+
+int Compiler::get_current_function_blocks() const {
+	return functions_blocks.back();
 }
 
 void Compiler::add_var(const std::string& name, jit_value_t value, const Type& type, bool ref) {

--- a/src/compiler/Compiler.hpp
+++ b/src/compiler/Compiler.hpp
@@ -25,6 +25,7 @@ public:
 
 	jit_function_t F = nullptr;
 	std::stack<jit_function_t> functions;
+	std::vector<int> functions_blocks; // how many blocks are open in the current loop
 
 	std::vector<int> loops_blocks; // how many blocks are open in the current loop
 	std::vector<jit_label_t*> loops_end_labels;
@@ -39,6 +40,7 @@ public:
 	void delete_variables_block(jit_function_t F, int deepness); // delete all variables in the #deepness current blocks
 	void enter_function(jit_function_t F);
 	void leave_function();
+	int get_current_function_blocks() const;
 
 	void add_var(const std::string& name, jit_value_t value, const Type& type, bool ref);
 	CompilerVar& get_var(const std::string& name);

--- a/src/compiler/instruction/Break.cpp
+++ b/src/compiler/instruction/Break.cpp
@@ -1,6 +1,4 @@
 #include "../../compiler/instruction/Break.hpp"
-
-#include "../../vm/value/LSNull.hpp"
 #include "../semantic/SemanticAnalyser.hpp"
 #include "../semantic/SemanticException.hpp"
 

--- a/src/compiler/instruction/Break.hpp
+++ b/src/compiler/instruction/Break.hpp
@@ -2,7 +2,6 @@
 #define BREAK_HPP
 
 #include "../../compiler/instruction/Instruction.hpp"
-#include "../../compiler/value/Expression.hpp"
 
 namespace ls {
 

--- a/src/compiler/instruction/Return.hpp
+++ b/src/compiler/instruction/Return.hpp
@@ -2,7 +2,6 @@
 #define RETURN_HPP
 
 #include "../../compiler/instruction/Instruction.hpp"
-#include "../../compiler/value/Expression.hpp"
 #include "../../compiler/value/Function.hpp"
 
 namespace ls {

--- a/src/compiler/syntaxic/SyntaxicAnalyser.cpp
+++ b/src/compiler/syntaxic/SyntaxicAnalyser.cpp
@@ -257,23 +257,11 @@ VariableDeclaration* SyntaxicAnalyser::eatVariableDeclaration() {
 		eat(TokenType::LET);
 	}
 
-//	if (t->type == TokenType::NEW) {
-//		vd->variables.push_back(t);
-//		eat();
-//	} else {
-		vd->variables.push_back(eatIdent());
-//	}
+	vd->variables.push_back(eatIdent());
 
 	while (t->type == TokenType::COMMA) {
-
 		eat(TokenType::COMMA);
-
-//		if (t->type == TokenType::NEW) {
-//			vd->variables.push_back(t);
-//			eat();
-//		} else {
-			vd->variables.push_back(eatIdent());
-//		}
+		vd->variables.push_back(eatIdent());
 	}
 
 	if (t->type == TokenType::EQUAL) {

--- a/src/compiler/syntaxic/SyntaxicAnalyser.cpp
+++ b/src/compiler/syntaxic/SyntaxicAnalyser.cpp
@@ -257,23 +257,23 @@ VariableDeclaration* SyntaxicAnalyser::eatVariableDeclaration() {
 		eat(TokenType::LET);
 	}
 
-	if (t->type == TokenType::NEW) {
-		vd->variables.push_back(t);
-		eat();
-	} else {
+//	if (t->type == TokenType::NEW) {
+//		vd->variables.push_back(t);
+//		eat();
+//	} else {
 		vd->variables.push_back(eatIdent());
-	}
+//	}
 
 	while (t->type == TokenType::COMMA) {
 
 		eat(TokenType::COMMA);
 
-		if (t->type == TokenType::NEW) {
-			vd->variables.push_back(t);
-			eat();
-		} else {
+//		if (t->type == TokenType::NEW) {
+//			vd->variables.push_back(t);
+//			eat();
+//		} else {
 			vd->variables.push_back(eatIdent());
-		}
+//		}
 	}
 
 	if (t->type == TokenType::EQUAL) {
@@ -282,7 +282,7 @@ VariableDeclaration* SyntaxicAnalyser::eatVariableDeclaration() {
 
 		vd->expressions.push_back(eatExpression());
 
-		while (t->type == TokenType::COMMA) {
+		while (t->type == TokenType::COMMA && vd->expressions.size() < vd->variables.size()) {
 			eat();
 			vd->expressions.push_back(eatExpression());
 		}

--- a/src/compiler/value/ArrayAccess.cpp
+++ b/src/compiler/value/ArrayAccess.cpp
@@ -199,7 +199,7 @@ jit_value_t ArrayAccess::compile(Compiler& c) const {
 			jit_value_t args[] = {a, k};
 			jit_value_t res = jit_insn_call_native(c.F, "access", func, sig, args, 2, JIT_CALL_NOTHROW);
 
-			if (key->type.nature == Nature::POINTER) {
+			if (key->type.must_manage_memory()) {
 				VM::delete_temporary(c.F, k);
 			}
 			VM::delete_temporary(c.F, a);

--- a/src/compiler/value/Expression.cpp
+++ b/src/compiler/value/Expression.cpp
@@ -315,7 +315,7 @@ LSValue* jit_ge(LSValue* x, LSValue* y) {
 LSValue* jit_store(LSValue** x, LSValue* y) {
 	y->refs++;
 	LSValue* r = *x = y;
-	LSValue::delete_val(y);
+	LSValue::delete_ref(y);
 	return r;
 }
 
@@ -475,8 +475,8 @@ jit_value_t Expression::compile(Compiler& c) const {
 					if (v2->type.must_manage_memory()) {
 						VM::inc_refs(c.F, y);
 					}
-					if (v2->type.must_manage_memory()) {
-						VM::delete_obj(c.F, x);
+					if (v1->type.must_manage_memory()) {
+						VM::delete_ref(c.F, x);
 					}
 					jit_insn_store(c.F, x, y);
 					return y;

--- a/src/compiler/value/FunctionCall.cpp
+++ b/src/compiler/value/FunctionCall.cpp
@@ -513,7 +513,7 @@ jit_value_t FunctionCall::compile(Compiler& c) const {
 
 		// Destroy temporary arguments
 		for (int i = 0; i < arg_count - 1; ++i) {
-			if (function->type.getArgumentType(i).nature == Nature::POINTER) {
+			if (function->type.getArgumentType(i).must_manage_memory()) {
 				VM::delete_temporary(c.F, args[i + 1]);
 			}
 		}

--- a/src/compiler/value/FunctionCall.cpp
+++ b/src/compiler/value/FunctionCall.cpp
@@ -645,7 +645,7 @@ jit_value_t FunctionCall::compile(Compiler& c) const {
 	// Destroy temporary arguments
 	for (int i = 0; i < arg_count; ++i) {
 		if (function->type.getArgumentType(i).must_manage_memory()) {
-			VM::delete_obj(c.F, args[i]);
+			VM::delete_ref(c.F, args[i]);
 		}
 	}
 

--- a/src/compiler/value/Match.cpp
+++ b/src/compiler/value/Match.cpp
@@ -147,7 +147,7 @@ jit_value_t Match::compile(Compiler& c) const {
 			jit_insn_store(c.F, res, ret);
 			jit_insn_label(c.F, &label_end);
 			if (value->type.must_manage_memory()) {
-				VM::delete_obj(c.F, v);
+				VM::delete_temporary(c.F, v);
 			}
 			return res;
 		}
@@ -179,7 +179,7 @@ jit_value_t Match::compile(Compiler& c) const {
 
 	jit_insn_label(c.F, &label_end);
 	if (value->type.must_manage_memory()) {
-		VM::delete_obj(c.F, v);
+		VM::delete_temporary(c.F, v);
 	}
 	return res;
 }
@@ -227,7 +227,7 @@ jit_value_t Match::Pattern::match(Compiler &c, jit_value_t v) const {
 				jit_value_t args[2] = { v, b };
 				ge = jit_insn_call_native(c.F, "", (void*) jit_greater_equal_, sig, args, 2, JIT_CALL_NOTHROW);
 				if (begin->type.must_manage_memory()) {
-					VM::delete_obj(c.F, b);
+					VM::delete_temporary(c.F, b);
 				}
 			}
 		}
@@ -241,7 +241,7 @@ jit_value_t Match::Pattern::match(Compiler &c, jit_value_t v) const {
 				jit_value_t args[2] = { v, e };
 				lt = jit_insn_call_native(c.F, "", (void*) jit_less_, sig, args, 2, JIT_CALL_NOTHROW);
 				if (end->type.must_manage_memory()) {
-					VM::delete_obj(c.F, e);
+					VM::delete_temporary(c.F, e);
 				}
 			}
 		}
@@ -270,7 +270,7 @@ jit_value_t Match::Pattern::match(Compiler &c, jit_value_t v) const {
 			jit_value_t args[2] = { v, p };
 			cond = jit_insn_call_native(c.F, "", (void*) jit_equals_, sig, args, 2, JIT_CALL_NOTHROW);
 			if (begin->type.must_manage_memory()) {
-				VM::delete_obj(c.F, p);
+				VM::delete_temporary(c.F, p);
 			}
 		}
 		return cond;

--- a/src/compiler/value/ObjectAccess.cpp
+++ b/src/compiler/value/ObjectAccess.cpp
@@ -25,7 +25,7 @@ ObjectAccess::ObjectAccess() {
 
 ObjectAccess::~ObjectAccess() {
 	delete object;
-	LSValue::delete_val(field_string);
+	delete field_string;
 }
 
 void ObjectAccess::print(ostream& os, int indent, bool debug) const {

--- a/src/compiler/value/PrefixExpression.cpp
+++ b/src/compiler/value/PrefixExpression.cpp
@@ -249,7 +249,7 @@ jit_value_t PrefixExpression::compile(Compiler& c) const {
 	}
 	jit_value_t result = jit_insn_call_native(c.F, "", func, sig, args.data(), 1, JIT_CALL_NOTHROW);
 
-	if (expression->type.nature == Nature::POINTER) {
+	if (expression->type.must_manage_memory()) {
 		VM::delete_temporary(c.F, args[0]);
 	}
 

--- a/src/compiler/value/String.cpp
+++ b/src/compiler/value/String.cpp
@@ -15,7 +15,7 @@ String::String(string& value, Token* token) {
 }
 
 String::~String() {
-	LSValue::delete_val(ls_string);
+	delete ls_string;
 }
 
 void String::print(ostream& os, int, bool debug) const {

--- a/src/vm/LSValue.cpp
+++ b/src/vm/LSValue.cpp
@@ -111,6 +111,7 @@ void LSValue::delete_ref(LSValue* value) {
 
 	if (value == nullptr) return;
 	if (value->native) return;
+	if (value->refs == 0) return;
 
 	value->refs--;
 	if (value->refs == 0) {

--- a/src/vm/LSValue.cpp
+++ b/src/vm/LSValue.cpp
@@ -107,19 +107,23 @@ LSValue* LSValue::move_inc() {
 	}
 }
 
-void LSValue::delete_val(LSValue* value) {
+void LSValue::delete_ref(LSValue* value) {
 
 	if (value == nullptr) return;
-
 	if (value->native) return;
 
-//	cout << "LSValue::delete_val " << flush;
-//	value->print(cout);
-//	cout << " " << value->refs << endl;
-
 	value->refs--;
-	if (value->refs <= 0) {
-		//cout << "delete LSValue" << endl;
+	if (value->refs == 0) {
+		delete value;
+	}
+}
+
+void LSValue::delete_temporary(LSValue* value)
+{
+	if (value == nullptr) return;
+	if (value->native) return;
+
+	if (value->refs == 0) {
 		delete value;
 	}
 }

--- a/src/vm/LSValue.cpp
+++ b/src/vm/LSValue.cpp
@@ -14,27 +14,27 @@ namespace ls {
 
 int LSValue::obj_count = 0;
 int LSValue::obj_deleted = 0;
-#if DEBUG
+#if DEBUG > 1
 	extern std::map<LSValue*, LSValue*> objs;
 #endif
 
 LSValue::LSValue() : refs(0), native(false) {
 	obj_count++;
-	#if DEBUG
+	#if DEBUG > 1
 		objs.insert({this, this});
 	#endif
 }
 
 LSValue::LSValue(const LSValue& other) : refs(0), native(other.native) {
 	obj_count++;
-	#if DEBUG
+	#if DEBUG > 1
 		objs.insert({this, this});
 	#endif
 }
 
 LSValue::~LSValue() {
 	obj_deleted++;
-	#if DEBUG
+	#if DEBUG > 1
 		objs.erase(this);
 	#endif
 }

--- a/src/vm/LSValue.hpp
+++ b/src/vm/LSValue.hpp
@@ -315,7 +315,8 @@ public:
 
 	static LSValue* parse(Json& json);
 
-	static void delete_val(LSValue* value);
+	static void delete_ref(LSValue* value);
+	static void delete_temporary(LSValue* value);
 };
 
 }

--- a/src/vm/Program.hpp
+++ b/src/vm/Program.hpp
@@ -1,7 +1,6 @@
 #ifndef PROGRAM_HPP
 #define PROGRAM_HPP
 
-#include "../compiler/value/Block.hpp"
 #include "../compiler/value/Function.hpp"
 #include "../compiler/semantic/SemanticAnalyser.hpp"
 

--- a/src/vm/VM.hpp
+++ b/src/vm/VM.hpp
@@ -6,7 +6,7 @@
 #include <jit/jit.h>
 
 #define OPERATION_LIMIT 10000000
-#define DEBUG 0
+#define DEBUG 1 // 0 no debug, 1 print types, 2 print leaks
 
 #define LS_INTEGER jit_type_int
 #define LS_LONG jit_type_long
@@ -72,10 +72,6 @@ public:
 	static jit_value_t move_obj(jit_function_t F, jit_value_t ptr);
 	static jit_value_t clone_obj(jit_function_t F, jit_value_t ptr);
 	static jit_value_t is_true(jit_function_t F, jit_value_t ptr);
-
-	jit_value_t new_array(jit_function_t F);
-	void push_array_value(jit_function_t F, jit_value_t array, jit_value_t value);
-	void push_array_pointer(jit_function_t F, jit_value_t array, jit_value_t value);
 };
 
 }

--- a/src/vm/VM.hpp
+++ b/src/vm/VM.hpp
@@ -6,7 +6,7 @@
 #include <jit/jit.h>
 
 #define OPERATION_LIMIT 10000000
-#define DEBUG 1 // 0 no debug, 1 print types, 2 print leaks
+#define DEBUG 1 // 0 no debug, 1 print types + #leaks, 2 print leak details
 
 #define LS_INTEGER jit_type_int
 #define LS_LONG jit_type_long
@@ -60,7 +60,7 @@ public:
 	static void inc_refs(jit_function_t F, jit_value_t obj);
 	static void inc_refs_if_not_temp(jit_function_t F, jit_value_t obj);
 	static void dec_refs(jit_function_t F, jit_value_t obj);
-	static void delete_obj(jit_function_t F, jit_value_t obj);
+	static void delete_ref(jit_function_t F, jit_value_t obj);
 	static void delete_temporary(jit_function_t F, jit_value_t obj);
 	static void inc_ops(jit_function_t F, int add);
 	static void get_operations(jit_function_t F);

--- a/src/vm/standard/StringSTD.cpp
+++ b/src/vm/standard/StringSTD.cpp
@@ -105,11 +105,11 @@ LSValue* string_map(const LSString* s, void* function) {
 		u_int32_t c = u8_nextchar(string_chars, &i);
 		u8_toutf8(buff, 5, &c, 1);
 		LSString* ch = new LSString(buff);
-		ch->refs = 1;
+		ch->refs = 1; // Why ?
 		LSString* res = (LSString*) fun(ch);
 		new_string += *res;
-		LSValue::delete_val(res);
-		LSValue::delete_val(ch);
+		LSValue::delete_temporary(res);
+		LSValue::delete_ref(ch);
 	}
 	return new LSString(new_string);
 }

--- a/src/vm/value/LSClass.cpp
+++ b/src/vm/value/LSClass.cpp
@@ -26,8 +26,8 @@ LSClass::LSClass(Json&) {
 
 LSClass::~LSClass() {
 	for (auto s : static_fields) {
-		if (s.second.value != nullptr) {
-			LSValue::delete_val(s.second.value);
+		if (s.second.value != nullptr && !s.second.value->native) {
+			delete s.second.value;
 		}
 	}
 }

--- a/src/vm/value/LSMap.tcc
+++ b/src/vm/value/LSMap.tcc
@@ -32,26 +32,26 @@ inline LSMap<K, T>::LSMap() {}
 template <>
 inline LSMap<LSValue*,LSValue*>::~LSMap() {
 	for (auto it = begin(); it != end(); ++it) {
-		LSValue::delete_val(it->first);
-		LSValue::delete_val(it->second);
+		LSValue::delete_ref(it->first);
+		LSValue::delete_ref(it->second);
 	}
 }
 template <>
 inline LSMap<LSValue*,int>::~LSMap() {
 	for (auto it = begin(); it != end(); ++it) {
-		LSValue::delete_val(it->first);
+		LSValue::delete_ref(it->first);
 	}
 }
 template <>
 inline LSMap<LSValue*,double>::~LSMap() {
 	for (auto it = begin(); it != end(); ++it) {
-		LSValue::delete_val(it->first);
+		LSValue::delete_ref(it->first);
 	}
 }
 template <>
 inline LSMap<int,LSValue*>::~LSMap() {
 	for (auto it = begin(); it != end(); ++it) {
-		LSValue::delete_val(it->second);
+		LSValue::delete_ref(it->second);
 	}
 }
 template <>
@@ -111,8 +111,8 @@ inline bool LSMap<int,double>::ls_insert(int key, double value) {
 template <>
 inline LSMap<LSValue*,LSValue*>* LSMap<LSValue*,LSValue*>::ls_clear() {
 	for (auto it = begin(); it != end(); ++it) {
-		LSValue::delete_val(it->first);
-		LSValue::delete_val(it->second);
+		LSValue::delete_ref(it->first);
+		LSValue::delete_ref(it->second);
 	}
 	clear();
 	return this;
@@ -120,7 +120,7 @@ inline LSMap<LSValue*,LSValue*>* LSMap<LSValue*,LSValue*>::ls_clear() {
 template <>
 inline LSMap<LSValue*,int>* LSMap<LSValue*,int>::ls_clear() {
 	for (auto it = begin(); it != end(); ++it) {
-		LSValue::delete_val(it->first);
+		LSValue::delete_ref(it->first);
 	}
 	clear();
 	return this;
@@ -128,7 +128,7 @@ inline LSMap<LSValue*,int>* LSMap<LSValue*,int>::ls_clear() {
 template <>
 inline LSMap<LSValue*,double>* LSMap<LSValue*,double>::ls_clear() {
 	for (auto it = begin(); it != end(); ++it) {
-		LSValue::delete_val(it->first);
+		LSValue::delete_ref(it->first);
 	}
 	clear();
 	return this;
@@ -136,7 +136,7 @@ inline LSMap<LSValue*,double>* LSMap<LSValue*,double>::ls_clear() {
 template <>
 inline LSMap<int,LSValue*>* LSMap<int,LSValue*>::ls_clear() {
 	for (auto it = begin(); it != end(); ++it) {
-		LSValue::delete_val(it->second);
+		LSValue::delete_ref(it->second);
 	}
 	clear();
 	return this;
@@ -156,8 +156,8 @@ template <>
 inline bool LSMap<LSValue*,LSValue*>::ls_erase(LSValue* key) {
 	auto it = find(key);
 	if (it != end()) {
-		LSValue::delete_val(it->first);
-		LSValue::delete_val(it->second);
+		LSValue::delete_ref(it->first);
+		LSValue::delete_ref(it->second);
 		erase(it);
 		return true;
 	}
@@ -167,7 +167,7 @@ template <>
 inline bool LSMap<LSValue*,int>::ls_erase(LSValue* key) {
 	auto it = find(key);
 	if (it != end()) {
-		LSValue::delete_val(it->first);
+		LSValue::delete_ref(it->first);
 		erase(it);
 		return true;
 	}
@@ -177,7 +177,7 @@ template <>
 inline bool LSMap<LSValue*,double>::ls_erase(LSValue* key) {
 	auto it = find(key);
 	if (it != end()) {
-		LSValue::delete_val(it->first);
+		LSValue::delete_ref(it->first);
 		erase(it);
 		return true;
 	}
@@ -187,7 +187,7 @@ template <>
 inline bool LSMap<int,LSValue*>::ls_erase(int key) {
 	auto it = find(key);
 	if (it != end()) {
-		LSValue::delete_val(it->second);
+		LSValue::delete_ref(it->second);
 		erase(it);
 		return true;
 	}

--- a/src/vm/value/LSNumber.cpp
+++ b/src/vm/value/LSNumber.cpp
@@ -402,7 +402,6 @@ std::ostream& LSNumber::print(std::ostream& os) const {
 }
 
 LSValue* LSNumber::getClass() const {
-	LSNumber::number_class->refs++;
 	return LSNumber::number_class;
 }
 

--- a/src/vm/value/LSObject.cpp
+++ b/src/vm/value/LSObject.cpp
@@ -40,7 +40,7 @@ LSObject::LSObject(Json& json) {
 
 LSObject::~LSObject() {
 	for (auto v : values) {
-		LSValue::delete_val(v.second);
+		LSValue::delete_ref(v.second);
 	}
 }
 
@@ -187,7 +187,7 @@ LSValue* LSObject::abso() const {
 LSValue* LSObject::clone() const {
 	LSObject* obj = new LSObject();
 	for (auto i = values.begin(); i != values.end(); i++) {
-		obj->values.insert({i->first, i->second->clone()});
+		obj->values.insert({i->first, i->second->clone_inc()});
 	}
 	return obj;
 }

--- a/test/function.cpp
+++ b/test/function.cpp
@@ -40,7 +40,8 @@ void Test::test_functions() {
 	success("let f = x -> [x, x, x] f(44)", "[44, 44, 44]");
 	success("let f = function(x) { let r = x ** 2 return r + 1 } f(10)", "101");
 	success("1; 2", "2");
-	success("return 1; 2", "1");
+	success("let x = 'leak' return '1'; 2", "'1'");
+	success("let x = '1' return x; 2", "'1'");
 	success("let f = function(x) { if (x < 10) {return true} return 12 } [f(5), f(20)]", "[true, 12]");
 	//	success("let a = 10 a ~ x -> x ^ 2", "100");
 	success("let f = x -> { let y = { if x == 0 { return 'error' } 1/x } '' + y } [f(-2), f(0), f(2)]", "['-0.5', 'error', '0.5']");

--- a/test/loops.cpp
+++ b/test/loops.cpp
@@ -119,9 +119,9 @@ void Test::test_loops() {
 	success("match 50 { ..50: 1 50..: 2 }", "2");
 	success("match 50 { ..10: 1 ..100: 2 }", "2");
 	success("match 50 { ..100: 1 ..100: 2 }", "1");
-	success("match 'e' { ..'b': 1 ..'z': 2 }", "2");
+	success("let e = 'e' match e { ..'b': 1 ..'z': 2 }", "2");
 	success("match 'e' { 'z'..: 1 'b'..: 2 }", "2");
 	success("match [1] { ..[]: 1 ..[2, 2]: 2 }", "2");
 	success("match [1] { [2, 2]..: 1 []..: 2 }", "2");
-	success("match 'e' { ..'b': 1 1..6|0..9: 2 ..|..: 3}", "3");
+	success("let b = 'b' match 'e' { ..b: 1 1..6|0..9: 2 ..|..: 3}", "3");
 }


### PR DESCRIPTION
- Fix `return` leaks (see new tests)
- Modify behavior of `delete_obj` (renamed in `delete_ref`) now the function does not affects temporary variables
- Add true move for the block return variable (see example below)
- Small changes into `eatVariableDeclaration`

```
{
    let a = 'test'
    // a.refs == 1
    a
}
```

When returning `a` the block know that he has the ownership of `a`. It can do what the fuck it want with, so now it simply convert `a` into a temporary variable and return it directly. 
