### PR TITLE
[Benchmark] More comprehensible display

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,12 @@ build/leekscript-benchmark: benchmark-dir build/leekscript $(OBJ_BENCHMARK)
 # Run a benchmark
 benchmark: build/leekscript-benchmark
 	@build/leekscript-benchmark
+	@rm results
+
+# Run a benchmark on operator
+benchmark-op: build/leekscript-benchmark
+	@build/leekscript-benchmark -o
+	@rm result
 
 # Valgrind
 # `apt install valgrind`

--- a/benchmark/Benchmark.cpp
+++ b/benchmark/Benchmark.cpp
@@ -191,11 +191,11 @@ void test_operator() {
 void Benchmark::operators() {
 	std::cout << "Starting benchmark..." << std::endl;
 	auto b = run_operator("", true);
-	std::cout << "base time: " << (b / 1000000) << " ms" << std::endl;
+	std::cout << pad("base time: ", 15) <<  (b / 1000000) << " ms" << std::endl;
 
 	for (auto& o : {"+", "-", "*", "/", "\\", "^", "&", "|", "%", "%%", "**", "&&"}) {
 		auto t = run_operator(o);
-		std::cout << "operator " << o << " : " << (t / 1000000) << " ms" << std::endl;
+		std::cout << pad(string("operator ") + o + " : ", 15) << pad(format_ns(t, b), 15) << std::endl;
 	}
 }
 


### PR DESCRIPTION
Ajout d'une commande Makefile pour lancer le test des opérateurs : make benchmark-op
"result" et "results", des fichiers créé par le Benchmark sont maintenant ignoré par git
Ajout du facteur entre la base et le temps d’exécution opérateurs (comme pour le Benchmark classique).