### PR TITLE
[Test] Optionals arguments to select test to make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ build/leekscript-coverage: $(BUILD_DIR) $(OBJ_COVERAGE) $(OBJ_TEST)
 
 # Run tests
 test: build/leekscript-test
-	@build/leekscript-test
+	@build/leekscript-test $(SELECTED)
 
 # Benchmark
 benchmark-dir:

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -18,38 +18,37 @@ Test::Test() : vmv1(true) {
 
 Test::~Test() {}
 
-int main(int, char**) {
+int main(int argc, char** argv) {
 	srand(time(0));
-	return Test().all();
+	if (argc <= 1) {
+		return Test().all();
+	} else {
+		std::set<std::string> args = {};
+		for (int c = 1; c < argc; ++c)
+			args.emplace(argv[c]);
+			return Test().selected(args);
+	}
 }
 
 int Test::all() {
+#define F(func, str) str,
+	return selected(
+		{
+			LIST_TEST(F)
+		}
+	);
+#undef F
+}
+
+int Test::selected(std::set<std::string> tests_selected) {
 
 	clock_t begin = clock();
 	exeTime = 0;
 
-	test_general();
-	test_types();
-	test_booleans();
-	test_numbers();
-	test_strings();
-	test_arrays();
-	test_intervals();
-	test_map();
-	test_set();
-	test_objects();
-	test_functions();
-	test_classes();
-	test_loops();
-	test_operators();
-	test_references();
-	test_exceptions();
-	test_operations();
-	test_system();
-	test_json();
-	test_files();
-	test_doc();
-	test_utils();
+#define F(func, str) if (tests_selected.find(str) != tests_selected.end()) func();
+	LIST_TEST(F)
+#undef F
+
 
 	double elapsed_secs = double(clock() - begin) / CLOCKS_PER_SEC;
 	int errors = (total - success_count);

--- a/test/Test.hpp
+++ b/test/Test.hpp
@@ -3,8 +3,34 @@
 
 #include <iostream>
 #include <string>
+#include <set>
 #include "../src/vm/VM.hpp"
 #include "../src/vm/value/LSNumber.hpp"
+
+#define LIST_TEST(X) \
+	X(test_general, "gen") \
+	X(test_types, "type") \
+	X(test_booleans, "bool") \
+	X(test_numbers, "num") \
+	X(test_strings, "str") \
+	X(test_arrays, "arr") \
+	X(test_intervals, "int") \
+	X(test_map, "map") \
+	X(test_set, "set") \
+	X(test_objects, "obj") \
+	X(test_functions, "fun") \
+	X(test_classes, "cla") \
+	X(test_loops, "loop") \
+	X(test_operators, "optr") \
+	X(test_references, "ref") \
+	X(test_exceptions, "ex") \
+	X(test_operations, "opti") \
+	X(test_system, "sys") \
+	X(test_json, "json") \
+	X(test_files, "file") \
+	X(test_doc, "doc") \
+	X(test_utils, "util")
+	
 
 class Test {
 private:
@@ -27,6 +53,7 @@ public:
 	virtual ~Test();
 
 	int all();
+	int selected(std::set<std::string> tests_selected);
 	void header(std::string);
 	void section(std::string);
 
@@ -35,28 +62,9 @@ public:
 	Input file(const std::string& file_name);
 	Input file_v1(const std::string& file_name);
 
-	void test_general();
-	void test_types();
-	void test_operations();
-	void test_operators();
-	void test_references();
-	void test_system();
-	void test_objects();
-	void test_strings();
-	void test_numbers();
-	void test_booleans();
-	void test_arrays();
-	void test_map();
-	void test_set();
-	void test_functions();
-	void test_loops();
-	void test_classes();
-	void test_files();
-	void test_doc();
-	void test_intervals();
-	void test_json();
-	void test_exceptions();
-	void test_utils();
+#define F(func, str) void func();
+	LIST_TEST(F)
+#undef F
 
 	class Input {
 	public:
@@ -92,6 +100,8 @@ public:
 		void pass(std::string expected);
 		void fail(std::string expected, std::string actuel);
 	};
+
+	
 };
 
 


### PR DESCRIPTION
Utilisation avec le makefile : `make test SELECTED="..."`
Avec les "..." remplacé par un ou plusieurs de ces abréviations (ça reste modifiable les abbr) :
"gen", "type", "bool", "num", "str", "arr", "int", "map", "set", "obj", "fun", "cla", "loop", "optr", "ref", "ex", "opti", "sys", "json", "file", "doc", "util"

Pour ajouter facilement des tests à l'avenir, il suffit de rajouter une ligne en haut de Test.hpp dans la macro
`X(nom_fonction, abbreviation) \`


